### PR TITLE
feat: AWS Cognito認証基盤 + パックAPI + DB移行

### DIFF
--- a/client/hooks/usePacks.ts
+++ b/client/hooks/usePacks.ts
@@ -1,50 +1,157 @@
-import { useCallback, useMemo, useState } from 'react';
-import type { Pack } from '../utils/types';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Pack, ApiResponse } from '../utils/types';
+import { API_CONFIG } from '../services/api.client';
 
 const STORAGE_KEY = 'ul_packs_v1';
-const LEGACY_LOCAL_USER_ID = 'local-user';
+const BASE_URL = API_CONFIG.baseUrl;
 
-type StoredPack = Partial<Pack> & Pick<Pack, 'id' | 'name' | 'itemIds' | 'isPublic' | 'createdAt' | 'updatedAt'>;
+/** サーバーが返す snake_case 形式のパックデータ */
+interface PackRow {
+  id: string;
+  user_id: string;
+  name: string;
+  route_name: string | null;
+  description: string | null;
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+  item_count?: number;
+  total_weight?: number;
+}
 
-const normalizePack = (pack: StoredPack): Pack => ({
-  ...pack,
-  userId: pack.userId || LEGACY_LOCAL_USER_ID,
-  routeName: pack.routeName?.trim() || undefined,
-  description: pack.description?.trim() || undefined,
-}) as Pack;
+/** snake_case → camelCase に変換し Pack 型にマッピング */
+const toClientPack = (row: PackRow, itemIds: string[] = []): Pack => ({
+  id: row.id,
+  userId: row.user_id,
+  name: row.name,
+  routeName: row.route_name || undefined,
+  description: row.description || undefined,
+  itemIds,
+  isPublic: row.is_public,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
 
-const readPacks = (): Pack[] => {
+/** localStorage から旧パックデータを読み出す（移行用） */
+const readLocalPacks = (): Pack[] => {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return parsed.map((pack) => normalizePack(pack as StoredPack));
+    return parsed as Pack[];
   } catch {
     return [];
   }
 };
 
-const writePacks = (packs: Pack[]) => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(packs));
+/** 共通のfetchラッパー */
+const apiFetch = async <T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> => {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+    signal: AbortSignal.timeout(API_CONFIG.timeout.standard),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      (errorData as { message?: string }).message ||
+        `HTTP error! status: ${response.status}`,
+    );
+  }
+
+  const result: ApiResponse<T> = await response.json();
+  if (!result.success) {
+    throw new Error(result.message || 'API request failed');
+  }
+  return result.data;
 };
 
 export const usePacks = (userId: string) => {
-  const [packs, setPacks] = useState<Pack[]>(() => readPacks());
+  const [packs, setPacks] = useState<Pack[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const initializedRef = useRef(false);
 
-  const userPacks = useMemo(
-    () =>
-      packs.filter(
-        (pack) => pack.userId === userId || pack.userId === LEGACY_LOCAL_USER_ID
-      ),
-    [packs, userId]
-  );
+  // ==================== 初期ロード + localStorage 移行 ====================
 
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
+    const initialize = async () => {
+      try {
+        setLoading(true);
+
+        // サーバーからパック一覧を取得
+        const serverRows = await apiFetch<PackRow[]>('/packs');
+
+        // サーバーが空で localStorage にデータがある場合は移行
+        const localPacks = readLocalPacks();
+        if (serverRows.length === 0 && localPacks.length > 0) {
+          console.info('localStorage → サーバーへパック移行開始');
+          const imported = await apiFetch<PackRow[]>('/packs/import', {
+            method: 'POST',
+            body: JSON.stringify({ packs: localPacks }),
+          });
+
+          // 移行後は localStorage を削除
+          localStorage.removeItem(STORAGE_KEY);
+          console.info(`${imported.length} 件のパックを移行完了`);
+
+          // 移行パックの itemIds を付与（移行元から引く）
+          const packsWithItems = imported.map((row) => {
+            const original = localPacks.find((lp) => lp.name === row.name);
+            return toClientPack(row, original?.itemIds ?? []);
+          });
+          setPacks(packsWithItems);
+        } else {
+          // 通常ロード: 各パックの itemIds を並列取得
+          const packsWithItems = await Promise.all(
+            serverRows.map(async (row) => {
+              try {
+                const itemIds = await apiFetch<string[]>(
+                  `/packs/${row.id}/items`,
+                );
+                return toClientPack(row, itemIds);
+              } catch {
+                return toClientPack(row, []);
+              }
+            }),
+          );
+          setPacks(packsWithItems);
+        }
+
+        setError(null);
+      } catch (err) {
+        console.error('パック一覧の取得に失敗:', err);
+        setError(
+          err instanceof Error ? err.message : 'パックの読み込みに失敗しました',
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void initialize();
+  }, []);
+
+  // ==================== パック操作（楽観的更新 + バックグラウンド同期） ====================
+
+  /**
+   * パック作成
+   * 楽観的にクライアントIDで即座に反映し、サーバー応答で差し替え
+   */
   const createPack = useCallback(
-    (name: string, description?: string, routeName?: string) => {
+    (name: string, description?: string, routeName?: string): Pack => {
       const now = new Date().toISOString();
-      const next: Pack = {
-        id: crypto.randomUUID(),
+      const tempId = crypto.randomUUID();
+      const optimistic: Pack = {
+        id: tempId,
         userId,
         name,
         routeName: routeName?.trim() || undefined,
@@ -52,101 +159,159 @@ export const usePacks = (userId: string) => {
         itemIds: [],
         isPublic: true,
         createdAt: now,
-        updatedAt: now
+        updatedAt: now,
       };
-      setPacks((prev) => {
-        const updated = [next, ...prev];
-        writePacks(updated);
-        return updated;
-      });
-      return next;
+
+      setPacks((prev) => [optimistic, ...prev]);
+
+      // バックグラウンドでサーバーに作成し、IDを差し替え
+      void apiFetch<PackRow>('/packs', {
+        method: 'POST',
+        body: JSON.stringify({
+          name,
+          description: description?.trim() || undefined,
+          routeName: routeName?.trim() || undefined,
+          isPublic: true,
+        }),
+      })
+        .then((row) => {
+          const serverPack = toClientPack(row, []);
+          setPacks((prev) =>
+            prev.map((p) => (p.id === tempId ? serverPack : p)),
+          );
+        })
+        .catch((err) => {
+          console.error('パック作成に失敗:', err);
+          // 楽観的更新をロールバック
+          setPacks((prev) => prev.filter((p) => p.id !== tempId));
+        });
+
+      return optimistic;
     },
-    [userId]
+    [userId],
   );
 
-  const updatePack = useCallback((id: string, updates: Partial<Omit<Pack, 'id' | 'userId' | 'createdAt'>>) => {
-    setPacks((prev) => {
-      const updated = prev.map((pack) =>
-        pack.id === id
-          ? {
-              ...pack,
-              ...updates,
-              routeName: updates.routeName?.trim() || undefined,
-              description: updates.description?.trim() || undefined,
-              updatedAt: new Date().toISOString()
-            }
-          : pack
+  /** パック更新 */
+  const updatePack = useCallback(
+    (id: string, updates: Partial<Omit<Pack, 'id' | 'userId' | 'createdAt'>>) => {
+      // 楽観的更新
+      setPacks((prev) =>
+        prev.map((pack) =>
+          pack.id === id
+            ? {
+                ...pack,
+                ...updates,
+                routeName: updates.routeName?.trim() || undefined,
+                description: updates.description?.trim() || undefined,
+                updatedAt: new Date().toISOString(),
+              }
+            : pack,
+        ),
       );
-      writePacks(updated);
-      return updated;
-    });
-  }, []);
 
+      // バックグラウンドでサーバーに反映
+      void apiFetch<PackRow>(`/packs/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          name: updates.name,
+          description: updates.description?.trim() || undefined,
+          routeName: updates.routeName?.trim() || undefined,
+          isPublic: updates.isPublic,
+        }),
+      }).catch((err) => {
+        console.error('パック更新に失敗:', err);
+      });
+    },
+    [],
+  );
+
+  /** パック削除 */
   const deletePack = useCallback((id: string) => {
-    setPacks((prev) => {
-      const updated = prev.filter((pack) => pack.id !== id);
-      writePacks(updated);
-      return updated;
+    setPacks((prev) => prev.filter((pack) => pack.id !== id));
+
+    void apiFetch<void>(`/packs/${id}`, { method: 'DELETE' }).catch((err) => {
+      console.error('パック削除に失敗:', err);
     });
   }, []);
 
+  /** アイテムのトグル（追加/削除） */
   const toggleItemInPack = useCallback((packId: string, itemId: string) => {
     setPacks((prev) => {
-      const updated = prev.map((pack) => {
-        if (pack.id !== packId) return pack;
-        const exists = pack.itemIds.includes(itemId);
-        const itemIds = exists
-          ? pack.itemIds.filter((id) => id !== itemId)
-          : [...pack.itemIds, itemId];
-        return {
-          ...pack,
-          itemIds,
-          updatedAt: new Date().toISOString()
-        };
+      const target = prev.find((p) => p.id === packId);
+      if (!target) return prev;
+
+      const exists = target.itemIds.includes(itemId);
+      const newItemIds = exists
+        ? target.itemIds.filter((id) => id !== itemId)
+        : [...target.itemIds, itemId];
+
+      // バックグラウンドでサーバーに反映
+      void apiFetch<string[]>(`/packs/${packId}/items`, {
+        method: 'PUT',
+        body: JSON.stringify({ gearIds: newItemIds }),
+      }).catch((err) => {
+        console.error('パックアイテム更新に失敗:', err);
       });
-      writePacks(updated);
-      return updated;
+
+      return prev.map((pack) =>
+        pack.id === packId
+          ? { ...pack, itemIds: newItemIds, updatedAt: new Date().toISOString() }
+          : pack,
+      );
     });
   }, []);
 
-  const addItemsToPack = useCallback((packId: string, itemIds: string[]) => {
+  /** 複数アイテムを一括追加 */
+  const addItemsToPack = useCallback((packId: string, itemIds: string[]): number => {
     if (itemIds.length === 0) return 0;
 
     let addedCount = 0;
-    setPacks((prev) => {
-      const updated = prev.map((pack) => {
-        if (pack.id !== packId) return pack;
-        const existing = new Set(pack.itemIds);
-        const uniqueNewIds = itemIds.filter((id) => !existing.has(id));
-        addedCount = uniqueNewIds.length;
-        if (addedCount === 0) return pack;
 
-        return {
-          ...pack,
-          itemIds: [...pack.itemIds, ...uniqueNewIds],
-          updatedAt: new Date().toISOString()
-        };
+    setPacks((prev) => {
+      const target = prev.find((p) => p.id === packId);
+      if (!target) return prev;
+
+      const existing = new Set(target.itemIds);
+      const uniqueNewIds = itemIds.filter((id) => !existing.has(id));
+      addedCount = uniqueNewIds.length;
+      if (addedCount === 0) return prev;
+
+      const newItemIds = [...target.itemIds, ...uniqueNewIds];
+
+      // バックグラウンドでサーバーに反映
+      void apiFetch<string[]>(`/packs/${packId}/items`, {
+        method: 'PUT',
+        body: JSON.stringify({ gearIds: newItemIds }),
+      }).catch((err) => {
+        console.error('パックアイテム一括追加に失敗:', err);
       });
-      writePacks(updated);
-      return updated;
+
+      return prev.map((pack) =>
+        pack.id === packId
+          ? { ...pack, itemIds: newItemIds, updatedAt: new Date().toISOString() }
+          : pack,
+      );
     });
 
     return addedCount;
   }, []);
 
+  /** IDからパックを取得 */
   const getPackById = useCallback(
     (packId: string) => packs.find((pack) => pack.id === packId),
-    [packs]
+    [packs],
   );
 
   return {
     allPacks: packs,
-    packs: userPacks,
+    packs,
     getPackById,
     createPack,
     updatePack,
     deletePack,
     toggleItemInPack,
     addItemsToPack,
+    loading,
+    error,
   };
 };

--- a/client/services/api.client.ts
+++ b/client/services/api.client.ts
@@ -40,12 +40,36 @@ export const API_ENDPOINTS = {
 }
 
 /**
- * Request headers
+ * 認証トークン取得関数の登録
+ * AuthContext の初期化時に setAuthTokenProvider を呼び出し、
+ * getIdToken 関数を登録する。以降 getHeaders() が自動的にトークンを付与する。
  */
-export const getHeaders = () => {
-  return {
+let authTokenProvider: (() => Promise<string | null>) | null = null;
+
+export const setAuthTokenProvider = (provider: () => Promise<string | null>) => {
+  authTokenProvider = provider;
+};
+
+/**
+ * Request headers（認証トークン付き）
+ */
+export const getHeaders = async (): Promise<Record<string, string>> => {
+  const headers: Record<string, string> = {
     'Content-Type': 'application/json',
+  };
+
+  if (authTokenProvider) {
+    try {
+      const token = await authTokenProvider();
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+    } catch {
+      // トークン取得失敗時は認証なしで続行
+    }
   }
+
+  return headers;
 }
 
 /**
@@ -98,7 +122,7 @@ export const callAPIWithRetry = async (
       
       const requestOptions: RequestInit = {
         method,
-        headers: getHeaders(),
+        headers: await getHeaders(),
       }
 
       if (method !== 'GET' && method !== 'DELETE') {

--- a/client/services/categoryApiService.ts
+++ b/client/services/categoryApiService.ts
@@ -1,5 +1,5 @@
 import { Category } from '../utils/types';
-import { API_CONFIG } from './api.client';
+import { API_CONFIG, getHeaders } from './api.client';
 
 /**
  * カテゴリAPI Service
@@ -9,12 +9,14 @@ export class CategoryApiService {
    * 全カテゴリ取得
    */
   static async getAllCategories(): Promise<Category[]> {
-    const response = await fetch(`${API_CONFIG.baseUrl}/categories`);
-    
+    const response = await fetch(`${API_CONFIG.baseUrl}/categories`, {
+      headers: await getHeaders(),
+    });
+
     if (!response.ok) {
       throw new Error('Failed to fetch categories');
     }
-    
+
     const result = await response.json();
     return result.data;
   }
@@ -25,17 +27,15 @@ export class CategoryApiService {
   static async createCategory(name: string, color: string): Promise<Category> {
     const response = await fetch(`${API_CONFIG.baseUrl}/categories`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: await getHeaders(),
       body: JSON.stringify({ name, color })
     });
-    
+
     if (!response.ok) {
       const result = await response.json();
       throw new Error(result.message || 'Failed to create category');
     }
-    
+
     const result = await response.json();
     return result.data;
   }
@@ -46,17 +46,15 @@ export class CategoryApiService {
   static async updateCategory(id: string, name: string, color: string): Promise<Category> {
     const response = await fetch(`${API_CONFIG.baseUrl}/categories/${id}`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
+      headers: await getHeaders(),
       body: JSON.stringify({ name, color })
     });
-    
+
     if (!response.ok) {
       const result = await response.json();
       throw new Error(result.message || 'Failed to update category');
     }
-    
+
     const result = await response.json();
     return result.data;
   }
@@ -66,13 +64,13 @@ export class CategoryApiService {
    */
   static async deleteCategory(id: string): Promise<void> {
     const response = await fetch(`${API_CONFIG.baseUrl}/categories/${id}`, {
-      method: 'DELETE'
+      method: 'DELETE',
+      headers: await getHeaders(),
     });
-    
+
     if (!response.ok) {
       const result = await response.json();
       throw new Error(result.message || 'Failed to delete category');
     }
   }
 }
-

--- a/client/services/gearApiService.ts
+++ b/client/services/gearApiService.ts
@@ -1,5 +1,5 @@
 import { GearItemWithCalculated, ApiResponse, PaginatedResponse } from '../utils/types';
-import { API_CONFIG } from './api.client';
+import { API_CONFIG, getHeaders } from './api.client';
 
 /**
  * Gear API Service - RESTful設計に基づく段階的実装
@@ -36,9 +36,7 @@ export class GearApiService {
       
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });
 
@@ -67,9 +65,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear/${id}`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });
 
@@ -103,9 +99,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear/summary`, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         signal: AbortSignal.timeout(API_CONFIG.timeout.light)
       });
 
@@ -129,9 +123,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         body: JSON.stringify(gearData),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });
@@ -161,9 +153,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear/${id}`, {
         method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         body: JSON.stringify(gearData),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });
@@ -193,9 +183,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear/${id}`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });
 
@@ -222,9 +210,7 @@ export class GearApiService {
     try {
       const response = await fetch(`${this.baseUrl}/gear`, {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: await getHeaders(),
         body: JSON.stringify({ ids }),
         signal: AbortSignal.timeout(API_CONFIG.timeout.standard)
       });

--- a/client/utils/AuthContext.tsx
+++ b/client/utils/AuthContext.tsx
@@ -1,4 +1,32 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react'
+import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react'
+import {
+  CognitoUserPool,
+  CognitoUser,
+  AuthenticationDetails,
+  CognitoUserAttribute,
+  CognitoUserSession,
+  ISignUpResult,
+} from 'amazon-cognito-identity-js'
+
+// --- Cognito設定 ---
+
+const COGNITO_USER_POOL_ID = import.meta.env.VITE_COGNITO_USER_POOL_ID as string | undefined
+const COGNITO_CLIENT_ID = import.meta.env.VITE_COGNITO_CLIENT_ID as string | undefined
+
+/** Cognito環境変数が設定されているかどうか */
+const isCognitoConfigured = (): boolean => {
+  return !!(COGNITO_USER_POOL_ID && COGNITO_CLIENT_ID)
+}
+
+/** CognitoUserPoolインスタンス（設定済みの場合のみ生成） */
+const userPool: CognitoUserPool | null = isCognitoConfigured()
+  ? new CognitoUserPool({
+      UserPoolId: COGNITO_USER_POOL_ID!,
+      ClientId: COGNITO_CLIENT_ID!,
+    })
+  : null
+
+// --- パスワードバリデーション ---
 
 /**
  * Amazon Cognito password policy validation
@@ -15,7 +43,7 @@ const validateCognitoPassword = (password: string): boolean => {
 
   // 必要な文字種の存在チェック
   const hasLowercase = /[a-z]/.test(password)
-  const hasUppercase = /[A-Z]/.test(password)  
+  const hasUppercase = /[A-Z]/.test(password)
   const hasNumbers = /\d/.test(password)
   const hasSpecialChar = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~`]/.test(password)
 
@@ -29,11 +57,13 @@ export const getPasswordRequirements = (): string[] => {
   return [
     '8文字以上128文字以下',
     '大文字を1文字以上含む (A-Z)',
-    '小文字を1文字以上含む (a-z)', 
+    '小文字を1文字以上含む (a-z)',
     '数字を1文字以上含む (0-9)',
     '記号を1文字以上含む (!@#$%^&* など)'
   ]
 }
+
+// --- 型定義 ---
 
 interface User {
   id: string
@@ -47,6 +77,14 @@ interface AuthContextType {
   isAuthenticated: boolean
   login: (email: string, password: string) => Promise<boolean>
   logout: () => void
+  /** Cognitoサインアップ（Cognito未設定時はエラーをthrow） */
+  signUp: (email: string, password: string, name?: string) => Promise<boolean>
+  /** 確認コード検証（サインアップ後のメール確認用） */
+  confirmSignUp: (email: string, code: string) => Promise<boolean>
+  /** 現在のIDトークンを取得（未認証時はnull） */
+  getIdToken: () => Promise<string | null>
+  /** API呼び出し用のAuthorizationヘッダーを取得 */
+  getAuthHeaders: () => Promise<Record<string, string>>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -59,90 +97,343 @@ export const useAuth = () => {
   return context
 }
 
+// --- ヘルパー関数 ---
+
+/**
+ * CognitoUserSessionからUser型へ変換
+ * IDトークンのペイロードからユーザー情報を抽出する
+ */
+const sessionToUser = (session: CognitoUserSession): User => {
+  const idToken = session.getIdToken()
+  const payload = idToken.decodePayload()
+  return {
+    id: payload['sub'] as string,
+    email: payload['email'] as string,
+    name: (payload['name'] as string) || undefined,
+    createdAt: new Date((payload['auth_time'] as number) * 1000).toISOString(),
+  }
+}
+
+/**
+ * CognitoUser.getSession()をPromise化
+ * セッションが有効ならそのまま返却、期限切れなら自動的にリフレッシュされる
+ */
+const getSessionAsync = (cognitoUser: CognitoUser): Promise<CognitoUserSession> => {
+  return new Promise((resolve, reject) => {
+    cognitoUser.getSession(
+      (error: Error | null, session: CognitoUserSession | null) => {
+        if (error || !session) {
+          reject(error || new Error('セッション取得に失敗しました'))
+          return
+        }
+        resolve(session)
+      }
+    )
+  })
+}
+
+/**
+ * Cognito signUp をPromise化
+ */
+const signUpAsync = (
+  email: string,
+  password: string,
+  attributes: CognitoUserAttribute[]
+): Promise<ISignUpResult> => {
+  if (!userPool) {
+    throw new Error('Cognitoが設定されていません')
+  }
+  return new Promise((resolve, reject) => {
+    userPool.signUp(email, password, attributes, [], (err, result) => {
+      if (err || !result) {
+        reject(err || new Error('サインアップに失敗しました'))
+        return
+      }
+      resolve(result)
+    })
+  })
+}
+
+/**
+ * Cognito confirmRegistration をPromise化
+ */
+const confirmRegistrationAsync = (
+  cognitoUser: CognitoUser,
+  code: string
+): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    cognitoUser.confirmRegistration(code, true, (err, result) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(result as string)
+    })
+  })
+}
+
+// --- AuthProvider ---
+
 interface AuthProviderProps {
   children: ReactNode
 }
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null)
+  // 現在のCognitoUserを保持（トークンリフレッシュ時に必要）
+  const cognitoUserRef = useRef<CognitoUser | null>(null)
 
-  const login = async (email: string, password: string): Promise<boolean> => {
-    // Input validation
-    if (!email || !password) {
+  /**
+   * Cognitoログイン処理
+   * authenticateUser をPromise化してセッション取得まで行う
+   */
+  const cognitoLogin = useCallback(async (email: string, password: string): Promise<boolean> => {
+    if (!userPool) {
       return false
     }
-    
-    // Email format validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      return false
-    }
-    
-    // Amazon Cognito password policy validation
-    if (!validateCognitoPassword(password)) {
-      return false
-    }
-    
-    // Demo authentication - in production, this would call a real API
+
+    const cognitoUser = new CognitoUser({
+      Username: email,
+      Pool: userPool,
+    })
+
+    const authDetails = new AuthenticationDetails({
+      Username: email,
+      Password: password,
+    })
+
+    return new Promise<boolean>((resolve) => {
+      cognitoUser.authenticateUser(authDetails, {
+        onSuccess: (session: CognitoUserSession) => {
+          const userData = sessionToUser(session)
+          setUser(userData)
+          cognitoUserRef.current = cognitoUser
+          resolve(true)
+        },
+        onFailure: (err: Error) => {
+          console.error('Cognito認証エラー:', err)
+          resolve(false)
+        },
+        newPasswordRequired: () => {
+          // 初回ログイン時のパスワード変更要求
+          // 現時点では未対応 - 必要に応じて拡張
+          console.warn('新しいパスワードの設定が必要です')
+          resolve(false)
+        },
+      })
+    })
+  }, [])
+
+  /**
+   * デモ認証（Cognito未設定時のフォールバック）
+   */
+  const demoLogin = useCallback(async (email: string, password: string): Promise<boolean> => {
     if (email === 'demo@example.com' && password === 'DemoPass123!') {
       const demoUser: User = {
         id: 'demo-user-1',
         email: 'demo@example.com',
         name: 'Demo User',
-        createdAt: new Date().toISOString()
+        createdAt: new Date().toISOString(),
       }
       setUser(demoUser)
-      
-      // Store in localStorage for persistence with error handling
+
+      // localStorageに保存（永続化）
       try {
         localStorage.setItem('auth-user', JSON.stringify(demoUser))
       } catch (error) {
-        console.warn('Failed to save user data to localStorage:', error)
-        // Continue without persistence - not critical for demo
+        console.warn('localStorageへのユーザーデータ保存に失敗:', error)
       }
       return true
     }
     return false
-  }
+  }, [])
 
-  const logout = () => {
+  /**
+   * ログイン処理
+   * Cognito設定済みの場合はCognito認証、未設定の場合はデモ認証にフォールバック
+   */
+  const login = useCallback(async (email: string, password: string): Promise<boolean> => {
+    // 入力値バリデーション
+    if (!email || !password) {
+      return false
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      return false
+    }
+
+    // Cognitoパスワードポリシーのバリデーション
+    if (!validateCognitoPassword(password)) {
+      return false
+    }
+
+    if (isCognitoConfigured()) {
+      return cognitoLogin(email, password)
+    }
+    return demoLogin(email, password)
+  }, [cognitoLogin, demoLogin])
+
+  /**
+   * ログアウト処理
+   */
+  const logout = useCallback(() => {
+    // Cognitoセッションのクリア
+    if (cognitoUserRef.current) {
+      cognitoUserRef.current.signOut()
+      cognitoUserRef.current = null
+    }
+
     setUser(null)
+
+    // デモモード用のlocalStorageクリア
     try {
       localStorage.removeItem('auth-user')
     } catch (error) {
-      console.warn('Failed to remove user data from localStorage:', error)
-      // Non-critical error, continue with logout
-    }
-  }
-
-  // Initialize auth state from localStorage
-  React.useEffect(() => {
-    try {
-      const stored = localStorage.getItem('auth-user')
-      if (stored) {
-        try {
-          const parsedUser = JSON.parse(stored)
-          setUser(parsedUser)
-        } catch (parseError) {
-          console.error('Failed to parse stored user data:', parseError)
-          try {
-            localStorage.removeItem('auth-user')
-          } catch (removeError) {
-            console.warn('Failed to remove invalid user data:', removeError)
-          }
-        }
-      }
-    } catch (storageError) {
-      console.warn('localStorage access failed:', storageError)
-      // Continue without persistence
+      console.warn('localStorageからのユーザーデータ削除に失敗:', error)
     }
   }, [])
 
-  const value = {
+  /**
+   * サインアップ処理（Cognito専用）
+   */
+  const signUp = useCallback(async (email: string, password: string, name?: string): Promise<boolean> => {
+    if (!isCognitoConfigured()) {
+      throw new Error('Cognitoが設定されていないため、サインアップは利用できません')
+    }
+
+    if (!validateCognitoPassword(password)) {
+      throw new Error('パスワードがCognitoポリシーを満たしていません')
+    }
+
+    const attributes: CognitoUserAttribute[] = [
+      new CognitoUserAttribute({ Name: 'email', Value: email }),
+    ]
+    if (name) {
+      attributes.push(new CognitoUserAttribute({ Name: 'name', Value: name }))
+    }
+
+    try {
+      await signUpAsync(email, password, attributes)
+      return true
+    } catch (error) {
+      console.error('Cognitoサインアップエラー:', error)
+      throw error
+    }
+  }, [])
+
+  /**
+   * サインアップ確認コード検証
+   */
+  const confirmSignUp = useCallback(async (email: string, code: string): Promise<boolean> => {
+    if (!userPool) {
+      throw new Error('Cognitoが設定されていないため、確認コード検証は利用できません')
+    }
+
+    const cognitoUser = new CognitoUser({
+      Username: email,
+      Pool: userPool,
+    })
+
+    try {
+      await confirmRegistrationAsync(cognitoUser, code)
+      return true
+    } catch (error) {
+      console.error('確認コード検証エラー:', error)
+      throw error
+    }
+  }, [])
+
+  /**
+   * 現在のIDトークンを取得
+   * セッションが期限切れの場合はCognitoが自動的にリフレッシュする
+   * デモモードではnullを返す
+   */
+  const getIdToken = useCallback(async (): Promise<string | null> => {
+    if (!cognitoUserRef.current) {
+      return null
+    }
+
+    try {
+      const session = await getSessionAsync(cognitoUserRef.current)
+      return session.getIdToken().getJwtToken()
+    } catch (error) {
+      console.error('IDトークン取得エラー:', error)
+      // セッション無効の場合はログアウト状態にする
+      setUser(null)
+      cognitoUserRef.current = null
+      return null
+    }
+  }, [])
+
+  /**
+   * API呼び出し用のAuthorizationヘッダーを返す
+   * トークンがある場合は Bearer トークンを含む
+   * デモモードやトークン取得失敗時は空オブジェクトを返す
+   */
+  const getAuthHeaders = useCallback(async (): Promise<Record<string, string>> => {
+    const token = await getIdToken()
+    if (token) {
+      return { Authorization: `Bearer ${token}` }
+    }
+    return {}
+  }, [getIdToken])
+
+  // --- API クライアントに認証トークンプロバイダーを登録 ---
+  React.useEffect(() => {
+    import('../services/api.client').then(({ setAuthTokenProvider }) => {
+      setAuthTokenProvider(getIdToken)
+    })
+  }, [getIdToken])
+
+  // --- 初期化: 既存セッションの復元 ---
+  React.useEffect(() => {
+    if (isCognitoConfigured() && userPool) {
+      // Cognitoモード: UserPoolからキャッシュ済みユーザーを復元
+      const currentUser = userPool.getCurrentUser()
+      if (currentUser) {
+        currentUser.getSession(
+          (error: Error | null, session: CognitoUserSession | null) => {
+            if (!error && session && session.isValid()) {
+              const userData = sessionToUser(session)
+              setUser(userData)
+              cognitoUserRef.current = currentUser
+            }
+          }
+        )
+      }
+    } else {
+      // デモモード: localStorageから復元
+      try {
+        const stored = localStorage.getItem('auth-user')
+        if (stored) {
+          try {
+            const parsedUser = JSON.parse(stored) as User
+            setUser(parsedUser)
+          } catch (parseError) {
+            console.error('保存済みユーザーデータのパースに失敗:', parseError)
+            try {
+              localStorage.removeItem('auth-user')
+            } catch (removeError) {
+              console.warn('不正なユーザーデータの削除に失敗:', removeError)
+            }
+          }
+        }
+      } catch (storageError) {
+        console.warn('localStorageアクセスに失敗:', storageError)
+      }
+    }
+  }, [])
+
+  const value: AuthContextType = {
     user,
     isAuthenticated: !!user,
     login,
-    logout
+    logout,
+    signUp,
+    confirmSignUp,
+    getIdToken,
+    getAuthHeaders,
   }
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@types/axios": "^0.9.36",
         "@types/cheerio": "^0.22.35",
+        "amazon-cognito-identity-js": "^6.3.16",
+        "aws-jwt-verify": "^5.1.1",
         "axios": "^1.11.0",
         "cheerio": "^1.1.2",
         "cors": "^2.8.5",
@@ -71,6 +73,62 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.2.2.tgz",
+      "integrity": "sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^1.2.2",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-1.2.2.tgz",
+      "integrity": "sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -999,6 +1057,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/types": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/@types/axios": {
       "version": "0.9.36",
       "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
@@ -1637,6 +1713,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/amazon-cognito-identity-js": {
+      "version": "6.3.16",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-6.3.16.tgz",
+      "integrity": "sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "1.2.2",
+        "buffer": "4.9.2",
+        "fast-base64-decode": "^1.0.0",
+        "isomorphic-unfetch": "^3.0.0",
+        "js-cookie": "^2.2.1"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
@@ -1758,6 +1847,15 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/aws-jwt-verify": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.1.1.tgz",
+      "integrity": "sha512-j6whGdGJmQ27agk4ijY8RPv6itb8JLb7SCJ86fEnneTcSBrpxuwL8kLq6y5WVH95aIknyAloEqAsaOLS1J8ITQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
@@ -1774,6 +1872,26 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/basic-auth": {
@@ -1906,6 +2024,17 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -3071,6 +3200,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-base64-decode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz",
+      "integrity": "sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3622,6 +3757,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3786,12 +3941,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3818,6 +3989,12 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4193,6 +4370,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -5835,6 +6032,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -5854,6 +6057,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "3.14.0",
@@ -5939,6 +6148,12 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -6094,6 +6309,12 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -6125,6 +6346,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@types/axios": "^0.9.36",
     "@types/cheerio": "^0.22.35",
+    "amazon-cognito-identity-js": "^6.3.16",
+    "aws-jwt-verify": "^5.1.1",
     "axios": "^1.11.0",
     "cheerio": "^1.1.2",
     "cors": "^2.8.5",

--- a/server/app.ts
+++ b/server/app.ts
@@ -12,6 +12,8 @@ import analyticsRoutes from './routes/analytics';
 import llmRoutes from './routes/llm';
 import authRoutes from './routes/auth';
 import imageProxyRoutes from './routes/imageProxy';
+import packRoutes from './routes/packs';
+import { cognitoAuth } from './middleware/cognitoAuth';
 
 // Load environment variables
 config();
@@ -73,13 +75,14 @@ app.get('/', (req, res) => {
   });
 });
 
-// API routes
-app.use('/api/v1/gear', gearRoutes);
-app.use('/api/v1/categories', categoryRoutes);
-app.use('/api/v1/analytics', analyticsRoutes);
-app.use('/api/v1/llm', strictLimiter, llmRoutes); // LLM APIには厳格なRate Limiting
-app.use('/api/v1/auth', authRoutes);
-app.use('/api/v1/image', imageProxyRoutes);
+// API routes（認証ミドルウェアをグローバルに適用）
+app.use('/api/v1/gear', cognitoAuth, gearRoutes);
+app.use('/api/v1/categories', cognitoAuth, categoryRoutes);
+app.use('/api/v1/analytics', cognitoAuth, analyticsRoutes);
+app.use('/api/v1/llm', cognitoAuth, strictLimiter, llmRoutes);
+app.use('/api/v1/auth', authRoutes); // 認証エンドポイント自体は認証不要
+app.use('/api/v1/image', imageProxyRoutes); // 画像プロキシは認証不要
+app.use('/api/v1/packs', packRoutes); // パック（内部で認証制御）
 
 // Error handling middleware
 app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/server/database/migrations/005_add_packs_and_profile.sql
+++ b/server/database/migrations/005_add_packs_and_profile.sql
@@ -1,0 +1,71 @@
+-- パック管理テーブル（localStorage → DB 移行）
+CREATE TABLE IF NOT EXISTS packs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(200) NOT NULL,
+    description TEXT,
+    route_name VARCHAR(200),
+    is_public BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS pack_items (
+    pack_id UUID NOT NULL REFERENCES packs(id) ON DELETE CASCADE,
+    gear_id UUID NOT NULL REFERENCES gear_items(id) ON DELETE CASCADE,
+    PRIMARY KEY (pack_id, gear_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_packs_user_id ON packs(user_id);
+CREATE INDEX IF NOT EXISTS idx_packs_public ON packs(is_public) WHERE is_public = true;
+CREATE INDEX IF NOT EXISTS idx_pack_items_gear_id ON pack_items(gear_id);
+
+-- packs の updated_at 自動更新
+CREATE TRIGGER update_packs_updated_at
+    BEFORE UPDATE ON packs
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- users テーブル拡張（プロフィール + 設定）
+ALTER TABLE users ADD COLUMN IF NOT EXISTS display_name VARCHAR(100);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS handle VARCHAR(50);
+ALTER TABLE users ADD COLUMN IF NOT EXISTS bio TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS header_image_url TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS weight_unit VARCHAR(2) DEFAULT 'g';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS locale VARCHAR(10) DEFAULT 'ja';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS cognito_sub VARCHAR(128) UNIQUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+-- cognito_sub でユーザー検索するインデックス
+CREATE INDEX IF NOT EXISTS idx_users_cognito_sub ON users(cognito_sub) WHERE cognito_sub IS NOT NULL;
+
+-- users の updated_at 自動更新
+CREATE TRIGGER update_users_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- AIアドバイザーの会話永続化
+CREATE TABLE IF NOT EXISTS advisor_sessions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    pack_id UUID REFERENCES packs(id) ON DELETE SET NULL,
+    title VARCHAR(200),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS advisor_messages (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    session_id UUID NOT NULL REFERENCES advisor_sessions(id) ON DELETE CASCADE,
+    role VARCHAR(10) NOT NULL CHECK (role IN ('user', 'assistant')),
+    content TEXT NOT NULL,
+    suggested_edits JSONB,
+    gear_refs JSONB,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_advisor_sessions_user_id ON advisor_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_advisor_messages_session_id ON advisor_messages(session_id);
+
+CREATE TRIGGER update_advisor_sessions_updated_at
+    BEFORE UPDATE ON advisor_sessions
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/server/middleware/cognitoAuth.ts
+++ b/server/middleware/cognitoAuth.ts
@@ -1,0 +1,87 @@
+import { Request, Response, NextFunction } from 'express';
+import { CognitoJwtVerifier } from 'aws-jwt-verify';
+
+// Cognito JWT 検証ミドルウェア
+// 開発時は COGNITO_USER_POOL_ID が未設定なら認証をスキップ（DEMO_USER_ID を使用）
+
+const DEMO_USER_ID = '550e8400-e29b-41d4-a716-446655440100';
+
+// 型拡張: req に userId を追加
+declare module 'express-serve-static-core' {
+  interface Request {
+    userId?: string;
+  }
+}
+
+// Cognito が設定されている場合のみ Verifier を生成
+const userPoolId = process.env.COGNITO_USER_POOL_ID;
+const clientId = process.env.COGNITO_CLIENT_ID;
+
+const verifier = userPoolId && clientId
+  ? CognitoJwtVerifier.create({
+      userPoolId,
+      tokenUse: 'id',
+      clientId,
+    })
+  : null;
+
+/**
+ * 認証ミドルウェア
+ * - Cognito 設定済み: JWT を検証し req.userId に sub を設定
+ * - Cognito 未設定（開発時）: DEMO_USER_ID をフォールバック
+ */
+export async function cognitoAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  // Cognito 未設定 → 開発モード（DEMO_USER_ID）
+  if (!verifier) {
+    req.userId = DEMO_USER_ID;
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({
+      success: false,
+      message: 'Authorization header required',
+    });
+    return;
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const payload = await verifier.verify(token);
+    req.userId = payload.sub;
+    next();
+  } catch (error) {
+    console.error('JWT verification failed:', error);
+    res.status(401).json({
+      success: false,
+      message: 'Invalid or expired token',
+    });
+  }
+}
+
+/**
+ * オプショナル認証（公開エンドポイント用）
+ * トークンがあれば検証してユーザーIDを設定、なくてもリクエストを通す
+ */
+export async function optionalAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (!verifier) {
+    req.userId = DEMO_USER_ID;
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next(); // トークンなし → 未認証で続行
+  }
+
+  const token = authHeader.slice(7);
+  try {
+    const payload = await verifier.verify(token);
+    req.userId = payload.sub;
+  } catch {
+    // トークン無効でも続行（公開ページ用）
+  }
+  next();
+}

--- a/server/routes/packs.ts
+++ b/server/routes/packs.ts
@@ -1,0 +1,292 @@
+import { Router, Request, Response } from 'express';
+import { Pool } from 'pg';
+import { cognitoAuth, optionalAuth } from '../middleware/cognitoAuth';
+
+const router = Router();
+
+const pool = new Pool({
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '5433'),
+  database: process.env.DB_NAME || 'gear_manager',
+  user: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || 'password',
+});
+
+// ==================== パック CRUD ====================
+
+// GET /api/v1/packs - ユーザーのパック一覧
+router.get('/', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const result = await pool.query(
+      `SELECT p.*,
+              COUNT(pi.gear_id)::int AS item_count,
+              COALESCE(SUM(g.weight_grams * g.required_quantity), 0)::int AS total_weight
+       FROM packs p
+       LEFT JOIN pack_items pi ON p.id = pi.pack_id
+       LEFT JOIN gear_items g ON pi.gear_id = g.id
+       WHERE p.user_id = $1
+       GROUP BY p.id
+       ORDER BY p.updated_at DESC`,
+      [req.userId]
+    );
+
+    res.json({ success: true, data: result.rows });
+  } catch (error) {
+    console.error('Error fetching packs:', error);
+    res.status(500).json({ success: false, message: 'Failed to fetch packs' });
+  }
+});
+
+// POST /api/v1/packs - パック作成
+router.post('/', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { name, description, routeName, isPublic } = req.body;
+    if (!name) {
+      res.status(400).json({ success: false, message: 'Pack name is required' });
+      return;
+    }
+
+    const result = await pool.query(
+      `INSERT INTO packs (user_id, name, description, route_name, is_public)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [req.userId, name, description || null, routeName || null, isPublic || false]
+    );
+
+    res.status(201).json({ success: true, data: result.rows[0] });
+  } catch (error) {
+    console.error('Error creating pack:', error);
+    res.status(500).json({ success: false, message: 'Failed to create pack' });
+  }
+});
+
+// PUT /api/v1/packs/:id - パック更新
+router.put('/:id', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { name, description, routeName, isPublic } = req.body;
+
+    const result = await pool.query(
+      `UPDATE packs SET
+         name = COALESCE($1, name),
+         description = COALESCE($2, description),
+         route_name = COALESCE($3, route_name),
+         is_public = COALESCE($4, is_public)
+       WHERE id = $5 AND user_id = $6
+       RETURNING *`,
+      [name, description, routeName, isPublic, id, req.userId]
+    );
+
+    if (result.rows.length === 0) {
+      res.status(404).json({ success: false, message: 'Pack not found' });
+      return;
+    }
+
+    res.json({ success: true, data: result.rows[0] });
+  } catch (error) {
+    console.error('Error updating pack:', error);
+    res.status(500).json({ success: false, message: 'Failed to update pack' });
+  }
+});
+
+// DELETE /api/v1/packs/:id - パック削除
+router.delete('/:id', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const result = await pool.query(
+      'DELETE FROM packs WHERE id = $1 AND user_id = $2 RETURNING id',
+      [id, req.userId]
+    );
+
+    if (result.rows.length === 0) {
+      res.status(404).json({ success: false, message: 'Pack not found' });
+      return;
+    }
+
+    res.json({ success: true, message: 'Pack deleted' });
+  } catch (error) {
+    console.error('Error deleting pack:', error);
+    res.status(500).json({ success: false, message: 'Failed to delete pack' });
+  }
+});
+
+// ==================== パックアイテム ====================
+
+// GET /api/v1/packs/:id/items - パック内のアイテム一覧
+router.get('/:id/items', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    // パックの所有者チェック
+    const packCheck = await pool.query(
+      'SELECT id FROM packs WHERE id = $1 AND user_id = $2',
+      [id, req.userId]
+    );
+    if (packCheck.rows.length === 0) {
+      res.status(404).json({ success: false, message: 'Pack not found' });
+      return;
+    }
+
+    const result = await pool.query(
+      'SELECT gear_id FROM pack_items WHERE pack_id = $1',
+      [id]
+    );
+
+    res.json({ success: true, data: result.rows.map(r => r.gear_id) });
+  } catch (error) {
+    console.error('Error fetching pack items:', error);
+    res.status(500).json({ success: false, message: 'Failed to fetch pack items' });
+  }
+});
+
+// PUT /api/v1/packs/:id/items - パック内アイテム全置換
+router.put('/:id/items', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { gearIds } = req.body;
+
+    if (!Array.isArray(gearIds)) {
+      res.status(400).json({ success: false, message: 'gearIds must be an array' });
+      return;
+    }
+
+    // パックの所有者チェック
+    const packCheck = await pool.query(
+      'SELECT id FROM packs WHERE id = $1 AND user_id = $2',
+      [id, req.userId]
+    );
+    if (packCheck.rows.length === 0) {
+      res.status(404).json({ success: false, message: 'Pack not found' });
+      return;
+    }
+
+    // トランザクションで全置換
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('DELETE FROM pack_items WHERE pack_id = $1', [id]);
+
+      if (gearIds.length > 0) {
+        const values = gearIds.map((gearId: string, i: number) => `($1, $${i + 2})`).join(',');
+        await client.query(
+          `INSERT INTO pack_items (pack_id, gear_id) VALUES ${values} ON CONFLICT DO NOTHING`,
+          [id, ...gearIds]
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+
+    res.json({ success: true, data: gearIds });
+  } catch (error) {
+    console.error('Error updating pack items:', error);
+    res.status(500).json({ success: false, message: 'Failed to update pack items' });
+  }
+});
+
+// ==================== 公開パック（認証不要） ====================
+
+// GET /api/v1/packs/public/:id - 公開パック取得
+router.get('/public/:id', optionalAuth, async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    const packResult = await pool.query(
+      `SELECT p.*, u.display_name AS author_name, u.handle AS author_handle
+       FROM packs p
+       LEFT JOIN users u ON p.user_id = u.id
+       WHERE p.id = $1 AND p.is_public = true`,
+      [id]
+    );
+
+    if (packResult.rows.length === 0) {
+      res.status(404).json({ success: false, message: 'Pack not found or not public' });
+      return;
+    }
+
+    // パック内のギアアイテムも取得
+    const itemsResult = await pool.query(
+      `SELECT g.id, g.name, g.brand, g.weight_grams, g.price_cents,
+              g.required_quantity, g.image_url, g.product_url,
+              c.name AS category_name, c.color AS category_color
+       FROM pack_items pi
+       JOIN gear_items g ON pi.gear_id = g.id
+       LEFT JOIN categories c ON g.category_id = c.id
+       WHERE pi.pack_id = $1
+       ORDER BY g.name`,
+      [id]
+    );
+
+    res.json({
+      success: true,
+      data: {
+        ...packResult.rows[0],
+        items: itemsResult.rows,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching public pack:', error);
+    res.status(500).json({ success: false, message: 'Failed to fetch public pack' });
+  }
+});
+
+// ==================== 一括インポート（localStorage移行用） ====================
+
+// POST /api/v1/packs/import - localStorage からの一括移行
+router.post('/import', cognitoAuth, async (req: Request, res: Response) => {
+  try {
+    const { packs } = req.body;
+    if (!Array.isArray(packs)) {
+      res.status(400).json({ success: false, message: 'packs must be an array' });
+      return;
+    }
+
+    const client = await pool.connect();
+    const importedPacks: any[] = [];
+
+    try {
+      await client.query('BEGIN');
+
+      for (const pack of packs) {
+        const packResult = await client.query(
+          `INSERT INTO packs (user_id, name, description, route_name, is_public)
+           VALUES ($1, $2, $3, $4, $5)
+           RETURNING *`,
+          [req.userId, pack.name, pack.description || null, pack.routeName || null, pack.isPublic || false]
+        );
+
+        const newPack = packResult.rows[0];
+
+        // パックアイテムの挿入
+        if (Array.isArray(pack.itemIds) && pack.itemIds.length > 0) {
+          const values = pack.itemIds.map((_: string, i: number) => `($1, $${i + 2})`).join(',');
+          await client.query(
+            `INSERT INTO pack_items (pack_id, gear_id) VALUES ${values} ON CONFLICT DO NOTHING`,
+            [newPack.id, ...pack.itemIds]
+          );
+        }
+
+        importedPacks.push(newPack);
+      }
+
+      await client.query('COMMIT');
+    } catch (e) {
+      await client.query('ROLLBACK');
+      throw e;
+    } finally {
+      client.release();
+    }
+
+    res.status(201).json({ success: true, data: importedPacks, message: `${importedPacks.length} packs imported` });
+  } catch (error) {
+    console.error('Error importing packs:', error);
+    res.status(500).json({ success: false, message: 'Failed to import packs' });
+  }
+});
+
+export default router;

--- a/server/routes/shared/userContext.ts
+++ b/server/routes/shared/userContext.ts
@@ -3,7 +3,19 @@ import { Request } from 'express';
 // 認証実装までの仮ユーザーID
 export const DEMO_USER_ID = '550e8400-e29b-41d4-a716-446655440100';
 
+/**
+ * リクエストからユーザーIDを取得
+ * 優先順位:
+ * 1. cognitoAuth ミドルウェアが設定した req.userId（JWT の sub）
+ * 2. x-user-id ヘッダー（開発用フォールバック）
+ * 3. DEMO_USER_ID（デフォルト）
+ */
 export function getRequestUserId(req: Request): string {
+  // cognitoAuth ミドルウェアが設定した userId を優先
+  if (req.userId) {
+    return req.userId;
+  }
+
   const headerUserId = req.headers['x-user-id'];
   if (typeof headerUserId === 'string' && headerUserId.length > 0) {
     return headerUserId;


### PR DESCRIPTION
## Summary
- AWS Cognito JWT検証ミドルウェア導入（未設定時はDEMO_USER_IDフォールバックで既存動作維持）
- パックCRUD API新規作成（`/api/v1/packs`）— 作成/更新/削除/公開パック/localStorage一括インポート
- DBマイグレーション: `packs`, `pack_items`, `advisor_sessions`, `advisor_messages` テーブル + `users` テーブル拡張（profile, weight_unit, cognito_sub）
- `AuthContext.tsx` を Cognito 対応に書き換え（`amazon-cognito-identity-js`）
- 全APIクライアント（gear, category, LLM）に認証ヘッダー自動付与
- `usePacks.ts` を localStorage → API通信に全面書き換え（初回ロード時に自動マイグレーション）

## Test plan
- [x] Cognito未設定（env vars なし）で既存動作が壊れないことを確認
- [x] パックの作成/更新/削除がAPI経由で動作すること
- [x] パック内アイテムの追加/削除が動作すること
- [x] 公開パック（`/api/v1/packs/public/:id`）が認証なしでアクセス可能
- [x] `npm run lint && npm run typecheck && npm run build` が全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)