### PR TITLE
feat: g/oz 単位切り替え UI 適用とタイポグラフィトークン化

### DIFF
--- a/client/components/AppDock.tsx
+++ b/client/components/AppDock.tsx
@@ -115,7 +115,7 @@ const AppDock: React.FC<AppDockProps> = ({
             aria-label="User menu"
           >
             {isAuthenticated ? (
-              <span className="h-6 w-6 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-[10px] font-semibold inline-flex items-center justify-center">
+              <span className="h-6 w-6 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-2xs font-semibold inline-flex items-center justify-center">
                 {userInitial}
               </span>
             ) : (

--- a/client/components/CompactSummary.tsx
+++ b/client/components/CompactSummary.tsx
@@ -68,13 +68,13 @@ const CompactSummary: React.FC<CompactSummaryProps> = ({ totals, viewMode = 'wei
             >
               <div className="flex items-center space-x-1 mb-0.5">
                 <span
-                  className={`text-[10px] font-bold w-4 h-4 flex items-center justify-center rounded shadow-sm transition-all duration-200 text-white bg-gray-600 ${
+                  className={`text-2xs font-bold w-4 h-4 flex items-center justify-center rounded shadow-sm transition-all duration-200 text-white bg-gray-600 ${
                     isClickable ? 'group-hover:scale-110' : ''
                   }`}
                 >
                   {stat.icon}
                 </span>
-                <span className="text-[10px] font-medium text-gray-500">
+                <span className="text-2xs font-medium text-gray-500">
                   {stat.label}
                 </span>
               </div>

--- a/client/components/ComparisonTable.tsx
+++ b/client/components/ComparisonTable.tsx
@@ -87,13 +87,13 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
                 >
                   <div className="flex items-start justify-between gap-1">
                     {/* A/B/C/D ラベル */}
-                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-200 text-gray-700 text-[10px] font-bold flex-shrink-0">
+                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-200 text-gray-700 text-2xs font-bold flex-shrink-0">
                       {ITEM_LABELS[index] || index + 1}
                     </span>
                     <div className="flex-1 min-w-0">
                       <div className="font-semibold text-gray-900 text-xs truncate">{item.name}</div>
                       {item.brand && (
-                        <div className="text-[10px] text-gray-600 mt-0.5 truncate">{item.brand}</div>
+                        <div className="text-2xs text-gray-600 mt-0.5 truncate">{item.brand}</div>
                       )}
                     </div>
                     {/* 削除ボタン */}
@@ -231,7 +231,7 @@ export const ComparisonTable: React.FC<ComparisonTableProps> = ({
                       item.seasons.map(season => (
                         <span
                           key={season}
-                          className="px-1.5 py-0.5 text-[10px] rounded-full bg-gray-200 text-gray-700"
+                          className="px-1.5 py-0.5 text-2xs rounded-full bg-gray-200 text-gray-700"
                         >
                           {season}
                         </span>

--- a/client/components/DetailPanel/CardGridView.tsx
+++ b/client/components/DetailPanel/CardGridView.tsx
@@ -31,7 +31,7 @@ const formatSeasons = (seasons?: string[]): string => {
 
 /** 展開セクションの詳細行 */
 const DetailRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
-  <div className="flex justify-between text-[10px] leading-relaxed">
+  <div className="flex justify-between text-2xs leading-relaxed">
     <span style={{ color: COLORS.text.muted }}>{label}</span>
     <span style={{ color: COLORS.text.secondary }}>{value}</span>
   </div>
@@ -44,7 +44,7 @@ const actionButtonStyle = {
   borderRadius: COMPONENT_RADIUS.control,
 } as const;
 
-const actionButtonClass = 'text-[10px] font-medium px-2 py-0.5 rounded transition-colors hover:bg-gray-100';
+const actionButtonClass = 'text-2xs font-medium px-2 py-0.5 rounded transition-colors hover:bg-gray-100';
 
 /** コンパクトテキストカードのグリッド表示 */
 const CardGridView: React.FC<CardGridViewProps> = ({
@@ -109,7 +109,7 @@ const CardGridView: React.FC<CardGridViewProps> = ({
                     type="button"
                     onClick={(e) => { e.stopPropagation(); onTogglePackItem(item.id); }}
                     className={[
-                      'absolute top-1 right-1 z-10 h-5 min-w-[34px] rounded-md px-1.5 text-[9px] font-semibold transition-colors',
+                      'absolute top-1 right-1 z-10 h-5 min-w-[34px] rounded-md px-1.5 text-3xs font-semibold transition-colors',
                       isInActivePack ? 'bg-gray-800 text-white' : 'bg-white/90 text-gray-600',
                     ].join(' ')}
                     title={`${isInActivePack ? 'Remove from' : 'Add to'} ${activePackName}`}
@@ -130,7 +130,7 @@ const CardGridView: React.FC<CardGridViewProps> = ({
                       {item.name}
                     </span>
                     <span
-                      className="text-[10px] font-bold flex-shrink-0 px-1 rounded"
+                      className="text-2xs font-bold flex-shrink-0 px-1 rounded"
                       style={{
                         color: getPriorityColor(item.priority),
                         backgroundColor: `${getPriorityColor(item.priority)}${PRIORITY_BG_OPACITY}`,
@@ -143,10 +143,10 @@ const CardGridView: React.FC<CardGridViewProps> = ({
 
                   {/* 2行目: 重量 + 価格 */}
                   <div className="flex items-center justify-between mt-0.5">
-                    <span className="text-[11px] font-semibold" style={{ color: COLORS.text.primary }}>
+                    <span className="text-xs font-semibold" style={{ color: COLORS.text.primary }}>
                       {formatWeight(item.weightGrams, weightUnit)}
                     </span>
-                    <span className="text-[11px]" style={{ color: COLORS.text.secondary }}>
+                    <span className="text-xs" style={{ color: COLORS.text.secondary }}>
                       {formatPrice(item.priceCents)}
                     </span>
                   </div>
@@ -154,14 +154,14 @@ const CardGridView: React.FC<CardGridViewProps> = ({
                   {/* 3行目: weightClass + カテゴリ + 所持/必要 */}
                   <div className="flex items-center justify-between mt-0.5">
                     <div className="flex items-center gap-1.5 min-w-0">
-                      <span className="text-[10px] font-medium" style={{ color: COLORS.text.muted }}>
+                      <span className="text-2xs font-medium" style={{ color: COLORS.text.muted }}>
                         {item.weightClass}
                       </span>
-                      <span className="text-[10px] truncate" style={{ color: COLORS.text.secondary }}>
+                      <span className="text-2xs truncate" style={{ color: COLORS.text.secondary }}>
                         {item.category?.name ?? '—'}
                       </span>
                     </div>
-                    <span className="text-[10px] flex-shrink-0" style={{ color: COLORS.text.muted }}>
+                    <span className="text-2xs flex-shrink-0" style={{ color: COLORS.text.muted }}>
                       {item.ownedQuantity}/{item.requiredQuantity}
                     </span>
                   </div>

--- a/client/components/DetailPanel/CompareView.tsx
+++ b/client/components/DetailPanel/CompareView.tsx
@@ -92,7 +92,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                         <TruncatedText
                           text={item.name}
                           maxLength={10}
-                          className="font-medium text-gray-900 text-[10px]"
+                          className="font-medium text-gray-900 text-2xs"
                         />
                       </div>
                     </th>
@@ -114,7 +114,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                           style={isMin ? { color: successTone.text } : isMax ? { color: errorTone.text } : undefined}
                         >
                           {weight}g
-                          {isMin && <span className="ml-0.5 text-[9px]">★</span>}
+                          {isMin && <span className="ml-0.5 text-3xs">★</span>}
                         </span>
                       </td>
                     );
@@ -134,7 +134,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                           style={isMin ? { color: successTone.text } : isMax ? { color: errorTone.text } : undefined}
                         >
                           {formatPrice(price)}
-                          {isMin && <span className="ml-0.5 text-[9px]">★</span>}
+                          {isMin && <span className="ml-0.5 text-3xs">★</span>}
                         </span>
                       </td>
                     );
@@ -160,7 +160,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                         <CategoryBadge
                           name={item.category.name}
                           color={item.category.color || COLORS.gray[500]}
-                          className="text-[10px] font-medium"
+                          className="text-2xs font-medium"
                         />
                       ) : (
                         <span className="text-gray-400">-</span>
@@ -173,7 +173,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                   <td className="py-1.5 pr-2 text-gray-500">Brand</td>
                   {comparedItems.map(item => (
                     <td key={item.id} className="text-center px-2 py-1.5">
-                      <span className="text-gray-700 text-[10px]">
+                      <span className="text-gray-700 text-2xs">
                         {item.brand || '-'}
                       </span>
                     </td>

--- a/client/components/GearAdvisorChat.tsx
+++ b/client/components/GearAdvisorChat.tsx
@@ -55,7 +55,7 @@ const GearRefChip: React.FC<{ ref_: GearRef; onClick: (gearId: string) => void }
     type="button"
     onClick={() => onClick(ref_.gearId)}
     title={`Jump to ${ref_.gearName}`}
-    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium
+    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
                bg-gray-100 dark:bg-slate-700 text-gray-700 dark:text-gray-200
                border border-gray-200 dark:border-slate-600
                hover:bg-gray-200 dark:hover:bg-slate-600 transition-colors"
@@ -165,7 +165,7 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
           <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100">
             UL Gear Advisor
           </h3>
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
             {scopeLabel}
             {baseWeightLabel && ` · Base ${baseWeightLabel}`}
             {gearContext.ulStatus && ` · ${gearContext.ulStatus.classification}`}
@@ -198,7 +198,7 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
                                  ? 'rounded-2xl rounded-br-sm bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900'
                                  : 'rounded-2xl rounded-bl-sm bg-gray-50 dark:bg-slate-800 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-slate-700'}`}>
                 <div className="whitespace-pre-wrap">{message.content}</div>
-                <div className={`text-[10px] mt-1 opacity-50 select-none
+                <div className={`text-2xs mt-1 opacity-50 select-none
                                  ${message.role === 'user' ? 'text-right' : ''}`}>
                   {TIME_FMT.format(message.timestamp)}
                 </div>
@@ -257,7 +257,7 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
               type="button"
               disabled={isLoading}
               onClick={() => sendText(qp.prompt)}
-              className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-[11px] font-medium
+              className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
                          whitespace-nowrap shrink-0
                          bg-white/60 dark:bg-slate-700/60 backdrop-blur
                          text-gray-700 dark:text-gray-200
@@ -304,7 +304,7 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
             Send
           </button>
         </div>
-        <p className="mt-1.5 text-[10px] text-gray-400 dark:text-gray-500">
+        <p className="mt-1.5 text-2xs text-gray-400 dark:text-gray-500">
           e.g. "How can I reduce my base weight?" · "What's my Big 3 total?"
         </p>
       </div>

--- a/client/components/GearChart.tsx
+++ b/client/components/GearChart.tsx
@@ -401,7 +401,7 @@ const GearChart: React.FC<GearChartProps> = React.memo(({
                     <button
                       type="button"
                       onClick={() => setChartDisplayMode('pie')}
-                      className={`h-5 px-1.5 rounded text-[10px] font-medium transition-all duration-150 inline-flex items-center gap-1 ${
+                      className={`h-5 px-1.5 rounded text-2xs font-medium transition-all duration-150 inline-flex items-center gap-1 ${
                         chartDisplayMode === 'pie'
                           ? 'bg-white dark:bg-slate-600 text-gray-700 dark:text-gray-200 shadow-sm'
                           : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -416,7 +416,7 @@ const GearChart: React.FC<GearChartProps> = React.memo(({
                     <button
                       type="button"
                       onClick={() => setChartDisplayMode('bar')}
-                      className={`h-5 px-1.5 rounded text-[10px] font-medium transition-all duration-150 inline-flex items-center gap-1 ${
+                      className={`h-5 px-1.5 rounded text-2xs font-medium transition-all duration-150 inline-flex items-center gap-1 ${
                         chartDisplayMode === 'bar'
                           ? 'bg-white dark:bg-slate-600 text-gray-700 dark:text-gray-200 shadow-sm'
                           : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'
@@ -462,15 +462,15 @@ const GearChart: React.FC<GearChartProps> = React.memo(({
                 <button
                   type="button"
                   onClick={() => handleCategoryClick(selectedData.name)}
-                  className="flex items-center gap-0.5 text-[10px] text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+                  className="flex items-center gap-0.5 text-2xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
                 >
                   <svg className="w-3 h-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                     <path d="M10 12L6 8l4-4"/>
                   </svg>
                   All
                 </button>
-                <span className="text-[10px] text-gray-400 dark:text-gray-500">/</span>
-                <span className="text-[10px] font-medium truncate" style={{ color: selectedData.color }}>
+                <span className="text-2xs text-gray-400 dark:text-gray-500">/</span>
+                <span className="text-2xs font-medium truncate" style={{ color: selectedData.color }}>
                   {selectedData.name}
                 </span>
               </div>

--- a/client/components/GearListHeader.tsx
+++ b/client/components/GearListHeader.tsx
@@ -79,7 +79,7 @@ const GearListHeader: React.FC<GearListHeaderProps> = ({
         <div className="inline-flex rounded-md p-0.5 bg-white/50 neu-inset">
           <button
             onClick={() => onViewChange('card')}
-            className={`px-1.5 py-0.5 rounded text-[10px] font-medium transition-all duration-200 ${
+            className={`px-1.5 py-0.5 rounded text-2xs font-medium transition-all duration-200 ${
               currentView === 'card' ? 'bg-white text-gray-700 shadow-sm' : 'text-gray-500'
             }`}
             aria-label="Card view"
@@ -88,7 +88,7 @@ const GearListHeader: React.FC<GearListHeaderProps> = ({
           </button>
           <button
             onClick={() => onViewChange('table')}
-            className={`px-1.5 py-0.5 rounded text-[10px] font-medium transition-all duration-200 ${
+            className={`px-1.5 py-0.5 rounded text-2xs font-medium transition-all duration-200 ${
               currentView === 'table' ? 'bg-white text-gray-700 shadow-sm' : 'text-gray-500'
             }`}
             aria-label="Table view"
@@ -97,7 +97,7 @@ const GearListHeader: React.FC<GearListHeaderProps> = ({
           </button>
           <button
             onClick={() => onViewChange('compare')}
-            className={`px-1.5 py-0.5 rounded text-[10px] font-medium transition-all duration-200 ${
+            className={`px-1.5 py-0.5 rounded text-2xs font-medium transition-all duration-200 ${
               currentView === 'compare' ? 'bg-gray-700 text-white shadow-sm' : 'text-gray-500'
             }`}
             aria-label="Comparison view"

--- a/client/components/GearTable/TableHeader.tsx
+++ b/client/components/GearTable/TableHeader.tsx
@@ -66,7 +66,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
   const COLUMNS = React.useMemo(() => buildColumns(unit), [unit])
 
   const thBase = 'gear-th px-1.5 py-1 sticky top-0 z-20 bg-white/95 dark:bg-slate-800/95 backdrop-blur'
-  const labelBase = 'inline-flex h-6 w-full items-center rounded px-1.5 text-[11px] leading-none font-medium'
+  const labelBase = 'inline-flex h-6 w-full items-center rounded px-1.5 text-xs leading-none font-medium'
   const inactiveText = 'text-gray-500 dark:text-gray-300'
   const hoverText = 'hover:text-gray-700 dark:hover:text-gray-100'
 
@@ -92,7 +92,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
       ? 'text-gray-700 dark:text-gray-100'
       : 'text-gray-400 dark:text-gray-500 group-hover:text-gray-600 dark:group-hover:text-gray-300'
     return (
-      <span className={`inline-flex w-3 justify-center text-[10px] leading-none ${color}`}>
+      <span className={`inline-flex w-3 justify-center text-2xs leading-none ${color}`}>
         {isActive ? (sortDirection === 'asc' ? '↑' : '↓') : '↕'}
       </span>
     )
@@ -216,7 +216,7 @@ const TableHeader: React.FC<TableHeaderProps> = ({
                   <button
                     type="button"
                     onClick={onCurrencyChange}
-                    className={`inline-flex h-full w-6 flex-shrink-0 items-center justify-center rounded text-[11px] leading-none font-medium px-0 ${inactiveText} ${hoverText}`}
+                    className={`inline-flex h-full w-6 flex-shrink-0 items-center justify-center rounded text-xs leading-none font-medium px-0 ${inactiveText} ${hoverText}`}
                     title="Toggle currency"
                     aria-label="Toggle currency"
                   >

--- a/client/components/PackTabBar.tsx
+++ b/client/components/PackTabBar.tsx
@@ -28,7 +28,7 @@ const PackTabBar: React.FC<PackTabBarProps> = ({
   };
 
   const tabClass = (isActive: boolean) => [
-    'pack-tab-shape relative -mb-px h-9 px-5 text-[11px] font-semibold transition-all duration-150 inline-flex items-center justify-center',
+    'pack-tab-shape relative -mb-px h-9 px-5 text-xs font-semibold transition-all duration-150 inline-flex items-center justify-center',
     isActive
       ? 'text-gray-900 dark:text-gray-100'
       : 'text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200',
@@ -73,7 +73,7 @@ const PackTabBar: React.FC<PackTabBarProps> = ({
             className="pack-tab-shape -mb-px h-8 px-4 flex items-center gap-1.5 bg-white border border-gray-200 border-b-white dark:bg-slate-800 dark:border-slate-600 dark:border-b-slate-800"
           >
             <input
-              className="h-5 w-28 text-[11px] font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
+              className="h-5 w-28 text-xs font-semibold bg-transparent border-none outline-none text-gray-900 dark:text-gray-100 placeholder-gray-400"
               placeholder="Pack name..."
               value={newPackName}
               onChange={(e) => setNewPackName(e.target.value)}

--- a/client/components/ProfileEditorModal.tsx
+++ b/client/components/ProfileEditorModal.tsx
@@ -9,7 +9,7 @@ interface ProfileEditorModalProps {
 }
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <label className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{children}</label>
+  <label className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{children}</label>
 );
 
 /** ギア入力と同じドラッグ&ドロップ画像選択UI（コンパクト版） */
@@ -44,14 +44,14 @@ const ImageDropZone: React.FC<{
           <button
             type="button"
             onClick={() => removeImage(onRemove)}
-            className="absolute top-1 right-1 h-5 w-5 rounded-full bg-red-500 text-white text-[10px] inline-flex items-center justify-center"
+            className="absolute top-1 right-1 h-5 w-5 rounded-full bg-red-500 text-white text-2xs inline-flex items-center justify-center"
           >
             ✕
           </button>
         </div>
       ) : (
         <div className="py-1">
-          <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-1">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
             Drag & drop or click to select
           </p>
           <input
@@ -63,7 +63,7 @@ const ImageDropZone: React.FC<{
           />
           <label
             htmlFor={inputId}
-            className="btn-secondary text-[11px] px-3 py-1 rounded cursor-pointer"
+            className="btn-secondary text-xs px-3 py-1 rounded cursor-pointer"
           >
             Choose Image
           </label>

--- a/client/components/ProfileHeader.tsx
+++ b/client/components/ProfileHeader.tsx
@@ -66,7 +66,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             {(profile.displayName?.trim()?.charAt(0) || 'U').toUpperCase()}
           </span>
           <div className="min-w-0">
-            <p className="text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">{profile.headerTitle}</p>
+            <p className="text-2xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{profile.headerTitle}</p>
             <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">{profile.displayName}</h2>
             {profile.bio && (
               <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-xs">{profile.bio}</p>
@@ -125,7 +125,7 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             aria-label="User menu"
           >
             {isAuthenticated ? (
-              <span className="h-5 w-5 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-[10px] font-semibold inline-flex items-center justify-center">
+              <span className="h-5 w-5 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-2xs font-semibold inline-flex items-center justify-center">
                 {userInitial}
               </span>
             ) : (

--- a/client/components/WeightBreakdownCard.tsx
+++ b/client/components/WeightBreakdownCard.tsx
@@ -65,7 +65,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Base */}
         <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-50">
           <BackpackIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-[10px] font-medium text-gray-500">
+          <span className="text-2xs font-medium text-gray-500">
             {WEIGHT_CLASS_CONFIG.base.label}
           </span>
           <span className="text-sm font-bold text-gray-900">
@@ -76,7 +76,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Worn */}
         <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-100">
           <ShirtIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-[10px] font-medium text-gray-500">
+          <span className="text-2xs font-medium text-gray-500">
             {WEIGHT_CLASS_CONFIG.worn.label}
           </span>
           <span className="text-sm font-bold text-gray-900">
@@ -87,7 +87,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Consumable */}
         <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-100">
           <UtensilsIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-[10px] font-medium text-gray-500">
+          <span className="text-2xs font-medium text-gray-500">
             {WEIGHT_CLASS_CONFIG.consumable.label}
           </span>
           <span className="text-sm font-bold text-gray-900">
@@ -105,21 +105,21 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
           <span className="text-gray-500">Packed Weight</span>
           <span className="font-medium text-gray-900">
             {formatWeight(breakdown.packedWeight, unit)}
-            <span className="text-[10px] text-gray-400 ml-1">(Base + Cons)</span>
+            <span className="text-2xs text-gray-400 ml-1">(Base + Cons)</span>
           </span>
         </div>
         <div className="flex justify-between items-center">
           <span className="text-gray-500">Skin-out Weight</span>
           <span className="font-medium text-gray-900">
             {formatWeight(breakdown.skinOutWeight, unit)}
-            <span className="text-[10px] text-gray-400 ml-1">(All)</span>
+            <span className="text-2xs text-gray-400 ml-1">(All)</span>
           </span>
         </div>
         <div className="flex justify-between items-center">
           <span className="text-gray-500">Big3</span>
           <span className="font-medium text-gray-700">
             {formatWeight(breakdown.big3, unit)}
-            <span className="text-[10px] text-gray-400 ml-1">(Pack+Shelter+Sleep)</span>
+            <span className="text-2xs text-gray-400 ml-1">(Pack+Shelter+Sleep)</span>
           </span>
         </div>
       </div>
@@ -127,10 +127,10 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
       {/* UL Progress Bar */}
       <div className="mt-3">
         <div className="flex justify-between items-center mb-1">
-          <span className="text-[10px] text-gray-500">
+          <span className="text-2xs text-gray-500">
             Base Weight: {formatWeightLarge(breakdown.baseWeight, unit)}
           </span>
-          <span className="text-[10px] text-gray-500">
+          <span className="text-2xs text-gray-500">
             {Math.round(ulProgress)}% of UL limit
           </span>
         </div>
@@ -147,7 +147,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
             }}
           />
         </div>
-        <div className="text-[9px] text-gray-400 mt-0.5 text-right">
+        <div className="text-3xs text-gray-400 mt-0.5 text-right">
           UL limit: {formatWeightLarge(UL_THRESHOLDS.ultralight, unit)}
         </div>
       </div>

--- a/client/components/charts/ChartSummaryFooter.tsx
+++ b/client/components/charts/ChartSummaryFooter.tsx
@@ -41,10 +41,10 @@ const SummaryStatCard: React.FC<SummaryStatCardProps> = ({
     <>
       <div className="flex items-center gap-1.5 mb-0.5 leading-none">
         {icon}
-        <span className="text-[10px] leading-none font-medium text-gray-600 dark:text-gray-300">{label}</span>
+        <span className="text-2xs leading-none font-medium text-gray-600 dark:text-gray-300">{label}</span>
       </div>
-      <span className="text-[11px] leading-none font-bold text-gray-900 dark:text-gray-100">{value}</span>
-      {subValue && <span className="text-[9px] leading-none mt-1 text-gray-500 dark:text-gray-400">{subValue}</span>}
+      <span className="text-xs leading-none font-bold text-gray-900 dark:text-gray-100">{value}</span>
+      {subValue && <span className="text-3xs leading-none mt-1 text-gray-500 dark:text-gray-400">{subValue}</span>}
     </>
   )
 

--- a/client/components/ui/CategoryBadge.tsx
+++ b/client/components/ui/CategoryBadge.tsx
@@ -16,7 +16,7 @@ const CategoryBadge: React.FC<CategoryBadgeProps> = ({ name, color, className = 
     border: `1px solid ${baseColor}40`
   };
 
-  const classes = `inline-flex w-[100px] items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium ${className}`.trim();
+  const classes = `inline-flex w-[100px] items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${className}`.trim();
 
   if (onClick) {
     return (

--- a/client/components/ui/SegmentedControl.tsx
+++ b/client/components/ui/SegmentedControl.tsx
@@ -33,7 +33,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({ options, className 
           disabled={option.isDisabled}
           title={option.title}
           aria-label={option.ariaLabel}
-          className={`gear-glass-chip h-6 px-2 rounded-md text-[10px] font-medium transition-all duration-200 inline-flex items-center gap-1 ${stateClass}`}
+          className={`gear-glass-chip h-6 px-2 rounded-md text-2xs font-medium transition-all duration-200 inline-flex items-center gap-1 ${stateClass}`}
         >
           {option.label}
         </button>

--- a/client/components/ui/WeightClassBadge.tsx
+++ b/client/components/ui/WeightClassBadge.tsx
@@ -83,7 +83,7 @@ const WeightClassBadge: React.FC<WeightClassBadgeProps> = ({ weightClass, isBig3
       </span>
       {isBig3 && (
         <span
-          className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-gray-200 text-gray-700"
+          className="px-1.5 py-0.5 text-2xs font-bold rounded bg-gray-200 text-gray-700"
           title="Big3: Backpack / Shelter / Sleep"
         >
           Big3

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -38,10 +38,14 @@
     --glass-noise-opacity: 0.035;
     --glass-key-shadow: 0.14;
     --glass-ambient-shadow: 0.08;
+    --gear-font-3xs: 9px;
     --gear-font-2xs: 10px;
     --gear-font-xs: 11px;
     --gear-font-sm: 12px;
     --gear-font-md: 14px;
+    --gear-font-lg: 16px;
+    --gear-font-xl: 18px;
+    --gear-font-2xl: 20px;
     --gear-badge-size: 20px;
     --gear-row-height: 60px;
     /* 角丸階層: 3層ルール */
@@ -321,7 +325,7 @@
   /* Gear table typography hierarchy */
   .gear-th {
     font-size: var(--gear-font-2xs);
-    @apply font-semibold tracking-[0.02em];
+    @apply font-semibold tracking-wide;
     color: var(--text-table-head, #4b5563);
   }
 
@@ -343,8 +347,8 @@
   }
 
   .gear-text-micro {
-    font-size: 11px;
-    @apply font-medium tracking-[0.03em];
+    font-size: var(--gear-font-xs);
+    @apply font-medium tracking-wide;
     color: var(--text-table-micro, #6b7280);
   }
 

--- a/client/utils/designSystem.ts
+++ b/client/utils/designSystem.ts
@@ -28,14 +28,23 @@ export const SPACING_SCALE = {
 // Font Family
 export const FONT_FAMILY = 'Inter, sans-serif' as const;
 
-// Minimal Typography (3 sizes only)
+// Typography scale — tailwind.config.js fontSize と globals.css の --gear-font-* と整合
+// 単一の真実: 値の変更は 3 ファイル全てに反映する
 export const FONT_SCALE = {
-  sm: 12,   // Small text (captions, labels)
-  base: 14, // Base text (body, inputs)
-  lg: 18,   // Large text (headings)
+  '3xs': 9,
+  '2xs': 10,
+  xs:    11,
+  sm:    12,
+  base:  14,
+  lg:    16,
+  xl:    18,
+  '2xl': 20,
 } as const;
 
-// 行間（フォントサイズ × 白銀比）
+/**
+ * @deprecated Tailwind の `leading-*` ユーティリティを優先。
+ * 既存のチャート系コンポーネントが参照しているため値は保持。
+ */
 export const LINE_HEIGHT_SCALE = {
   xs: 17,   // 12 × 1.414
   sm: 24,   // 17 × 1.414

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,18 @@ export default {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
       },
+      // Typography scale — --gear-font-* (globals.css) と整合
+      // Tailwind 組み込み値 (text-xs=12px / text-sm=14px ...) を 1 段下にずらして上書き
+      fontSize: {
+        '3xs':  ['9px',  { lineHeight: '1'    }],  // 新規: バッジ最小
+        '2xs':  ['10px', { lineHeight: '1'    }],  // 新規: ラベル・キャプション
+        'xs':   ['11px', { lineHeight: '1.5'  }],  // 上書き (旧 12px)
+        'sm':   ['12px', { lineHeight: '1.5'  }],  // 上書き (旧 14px)
+        'base': ['14px', { lineHeight: '1.5'  }],  // 上書き (旧 16px)
+        'lg':   ['16px', { lineHeight: '1.35' }],  // 上書き (旧 18px)
+        'xl':   ['18px', { lineHeight: '1.2'  }],  // 上書き (旧 20px)
+        '2xl':  ['20px', { lineHeight: '1.2'  }],  // 上書き (旧 24px)
+      },
       colors: {
         // Tailwind 標準クラス（text-gray-900 など）をトークンへ一致させる
         gray: {


### PR DESCRIPTION
## Summary

- **g/oz 単位切り替え (P2)**: `WeightUnitContext` + `WeightUnitToggle` を新設し、14+ の表示コンポーネントと編集入力を `formatWeight` 経由に統一。localStorage 永続化・ロケール別デフォルト対応。DB はグラム保存のまま、表示層で変換する方針に従う。
- **タイポグラフィ 8 段階トークン化**: `tailwind.config.js` / `globals.css` / `designSystem.ts` の 3 箇所に同じスケール（3xs..2xl, 9px..20px）を定義し SSOT 化。既存の `text-[Npx]` 任意値や非トークン値を canonical な `text-*` クラスへ置換（209+ 箇所、15+ ファイル）。
- 副次的に `comparisonHelpers.ts`（190 行・未使用）と重複していた `formatters.formatWeight` を削除。

注: 本来は 2 関心事のため別 PR が望ましいが、出荷スピードを優先しまとめて出す。

## Test plan

- [x] `npm run lint` / `npm run typecheck` / `npm run build` がローカルで通る
- [ ] g/oz トグルを切り替えるとチャート・テーブル・カードビュー・サマリーの全表示単位が連動する
- [ ] トグル状態がリロード後も維持される（localStorage \`ul_weight_unit_v1\`）
- [ ] 初回アクセス時、ブラウザロケールが en-US/en-LR/my の場合 oz、それ以外は g がデフォルトになる
- [ ] EditableWeightField で oz 入力 → 内部はグラムで保存され、再表示時に同じ oz 値が出る（丸め誤差が許容範囲）
- [ ] モバイル幅でトグル行が折り返さず見切れない
- [ ] タイポグラフィ置換後、各画面の文字サイズが視覚的に崩れていない（特にチャート凡例・テーブルヘッダ・バッジ類）