### PR TITLE
feat: DB移行完了 + STG自動デプロイ設定

### DIFF
--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -27,13 +28,13 @@ jobs:
         run: npm ci
 
       - name: Pull Vercel environment
-        run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel@latest pull --yes --environment=preview
 
       - name: Build with Vercel
-        run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: npx vercel@latest build
 
       - name: Deploy to Vercel (STG)
         id: deploy
         run: |
-          URL=$(npx vercel deploy --prebuilt --yes --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(npx vercel@latest deploy --prebuilt --yes)
           echo "url=$URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy STG (Vercel)
+name: Deploy STG (Vercel - Frontend)
 
 on:
   push:
@@ -11,6 +11,9 @@ jobs:
     environment:
       name: stg
       url: ${{ steps.deploy.outputs.url }}
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v4
@@ -23,14 +26,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Pull Vercel environment
+        run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build with Vercel
+        run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy to Vercel (STG)
         id: deploy
         run: |
-          URL=$(npx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(npx vercel deploy --prebuilt --yes --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$URL" >> $GITHUB_OUTPUT
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,110 @@
+# デプロイ設定
+
+UL Gear Manager の STG 環境自動デプロイ設定ドキュメント。
+
+## アーキテクチャ
+
+```
+┌─────────────┐         ┌──────────────┐         ┌──────────────┐
+│  GitHub     │  push   │  Vercel      │         │  Railway     │
+│  main       ├────────►│  (Frontend)  │         │  (Backend)   │
+└──────┬──────┘         └──────┬───────┘         └──────┬───────┘
+       │                       │                        │
+       │                       │ VITE_API_BASE_URL      │
+       │ GitHub連携 (Railway)  ├───────────────────────►│
+       └──────────────────────►│                        │
+                               │ /api/v1/*              │
+                               └───────────────────────►│
+                                                        │
+                                                 ┌──────┴───────┐
+                                                 │  Postgres    │
+                                                 │  (Railway)   │
+                                                 └──────────────┘
+```
+
+- **フロントエンド**: Vercel (GitHub Actions 経由)
+- **バックエンド**: Railway (GitHub 連携による自動デプロイ)
+- **DB**: Railway Postgres プラグイン
+
+## トリガー条件
+
+| 変更箇所 | Vercel | Railway |
+|---|:---:|:---:|
+| `client/**`, `vite.config.ts` | ○ | × |
+| `server/**` | ○ (念のため) | ○ |
+| `package.json`, `package-lock.json` | ○ | ○ |
+| `railway.json` | × | ○ |
+| `docs/**`, `*.md` | × | × |
+
+Railway 側は [railway.json](../railway.json) の `watchPatterns` で制御。
+Vercel 側は全 push でビルドするが、フロントのみなので軽量。
+
+## 初回セットアップ
+
+### 1. Railway (バックエンド)
+
+1. https://railway.app で新規プロジェクト作成
+2. "Deploy from GitHub repo" で本リポジトリを連携
+3. **Settings**:
+   - Root Directory: `/`
+   - Branch: `main`
+4. **Plugins**: Postgres を追加 (`DATABASE_URL` が自動注入される)
+5. **Variables** に以下を設定:
+   ```
+   NODE_ENV=production
+   COGNITO_USER_POOL_ID=<値>
+   COGNITO_CLIENT_ID=<値>
+   AWS_REGION=<値>
+   OPENAI_API_KEY=<値>
+   RATE_LIMIT_MAX=100
+   LLM_RATE_LIMIT_MAX=10
+   ```
+6. デプロイ完了後、公開 URL を控える (例: `ul-gear-api.up.railway.app`)
+7. 初回のみマイグレーション実行 (Railway CLI か一時的にエンドポイント経由)
+
+### 2. Vercel (フロントエンド)
+
+1. https://vercel.com で新規プロジェクト作成
+2. Framework Preset: **Vite**
+3. **Environment Variables**:
+   ```
+   VITE_API_BASE_URL=https://<Railway URL>/api/v1
+   VITE_COGNITO_USER_POOL_ID=<値>
+   VITE_COGNITO_CLIENT_ID=<値>
+   VITE_AWS_REGION=<値>
+   ```
+4. ローカルで `npx vercel link` を実行し、`.vercel/project.json` から ID を取得
+
+### 3. GitHub
+
+**Settings > Secrets and variables > Actions** に追加:
+
+| Secret 名 | 取得方法 |
+|---|---|
+| `VERCEL_TOKEN` | https://vercel.com/account/tokens で発行 |
+| `VERCEL_ORG_ID` | `.vercel/project.json` の `orgId` |
+| `VERCEL_PROJECT_ID` | `.vercel/project.json` の `projectId` |
+
+**Settings > Environments** で `stg` environment を作成 (ワークフローが参照)。
+
+## デプロイ運用
+
+### 手動トリガー
+
+GitHub Actions の "Deploy STG" から `workflow_dispatch` で手動実行可能。
+
+### ロールバック
+
+- **Vercel**: Deployments 画面で過去のデプロイを "Promote to Production"
+- **Railway**: Deployments タブで過去のリリースを "Redeploy"
+
+### ヘルスチェック
+
+- バックエンド: `GET https://<Railway URL>/api/health`
+- 失敗時は Railway が自動再起動 ([railway.json](../railway.json) の `restartPolicyType: ON_FAILURE`)
+
+## 関連ファイル
+
+- [railway.json](../railway.json) — Railway ビルド/起動設定
+- [.github/workflows/deploy-stg.yml](../.github/workflows/deploy-stg.yml) — Vercel デプロイ
+- [server/app.ts](../server/app.ts) — `process.env.PORT` / `/api/health`

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm ci && npm run server:build"
+  },
+  "deploy": {
+    "startCommand": "node server/dist/app.js",
+    "healthcheckPath": "/api/health",
+    "healthcheckTimeout": 100,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,13 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm ci && npm run server:build"
+    "buildCommand": "npm ci && npm run server:build",
+    "watchPatterns": [
+      "server/**",
+      "package.json",
+      "package-lock.json",
+      "railway.json"
+    ]
   },
   "deploy": {
     "startCommand": "node server/dist/app.js",

--- a/server/services/amazonScraper.ts
+++ b/server/services/amazonScraper.ts
@@ -63,7 +63,7 @@ export class AmazonScraper {
   /**
    * Amazon特化データ抽出（最適化版）
    */
-  private extractAmazonData($: cheerio.Root, url: string): LLMExtractionResult {
+  private extractAmazonData($: cheerio.CheerioAPI, url: string): LLMExtractionResult {
     const extractedFields: string[] = [];
     
     // JSON-LDを1回だけ取得（キャッシュ）
@@ -117,7 +117,7 @@ export class AmazonScraper {
   /**
    * Amazon製品名抽出（JSON-LDキャッシュ対応）
    */
-  private extractAmazonTitle($: cheerio.Root, jsonLd: any): string | undefined {
+  private extractAmazonTitle($: cheerio.CheerioAPI, jsonLd: any): string | undefined {
     // 1. JSON-LD構造化データから取得（最優先）
     if (jsonLd?.name && typeof jsonLd.name === 'string' && jsonLd.name.length > 5) {
       return this.cleanAmazonTitle(jsonLd.name);
@@ -139,7 +139,7 @@ export class AmazonScraper {
   /**
    * Amazonブランド抽出（改良版）
    */
-  private extractAmazonBrand($: cheerio.Root): string | undefined {
+  private extractAmazonBrand($: cheerio.CheerioAPI): string | undefined {
     const brandSelectors = [
       '[data-brand]',
       '#bylineInfo',
@@ -163,7 +163,7 @@ export class AmazonScraper {
   /**
    * Amazon画像URL抽出（JSON-LDキャッシュ対応）
    */
-  private extractAmazonImage($: cheerio.Root, jsonLd: any): string | undefined {
+  private extractAmazonImage($: cheerio.CheerioAPI, jsonLd: any): string | undefined {
     // 1. JSON-LD構造化データから取得（最優先）
     if (jsonLd?.image) {
       const imageUrl = Array.isArray(jsonLd.image) ? jsonLd.image[0] : jsonLd.image;
@@ -211,7 +211,7 @@ export class AmazonScraper {
   /**
    * Amazon価格抽出（複数価格タイプ対応）
    */
-  private extractAmazonPrice($: cheerio.Root): number | undefined {
+  private extractAmazonPrice($: cheerio.CheerioAPI): number | undefined {
     const priceSelectors = [
       '.a-price-whole',
       '.a-price .a-offscreen',
@@ -230,7 +230,7 @@ export class AmazonScraper {
   /**
    * Amazon仕様抽出（重量・寸法）- 複数セクションから抽出
    */
-  private extractAmazonSpecs($: cheerio.Root): { weightGrams?: number } {
+  private extractAmazonSpecs($: cheerio.CheerioAPI): { weightGrams?: number } {
     // Amazon商品ページの各セクションから重量情報を検索
     const sections = [
       { name: 'productDescription', selector: '#productDescription, .product-description, #aplus' },
@@ -254,7 +254,7 @@ export class AmazonScraper {
   /**
    * Amazonカテゴリ抽出（軽量版）
    */
-  private extractAmazonCategory($: cheerio.Root): string {
+  private extractAmazonCategory($: cheerio.CheerioAPI): string {
     // タイトルとパンくずリストのみ（高速化）
     const title = $('#productTitle').text();
     const breadcrumbs = $('#wayfinding-breadcrumbs_feature_div, .a-breadcrumb').text();
@@ -268,7 +268,7 @@ export class AmazonScraper {
   /**
    * Amazon評価・レビュー情報
    */
-  private extractAmazonRatings($: cheerio.Root): { rating?: number; reviewCount?: number } {
+  private extractAmazonRatings($: cheerio.CheerioAPI): { rating?: number; reviewCount?: number } {
     const rating = parseFloat($('[data-hook="average-star-rating"] .a-offscreen').first().text().replace(/[^\d.]/g, '')) || undefined;
     const reviewCountText = $('[data-hook="total-review-count"]').first().text();
     const reviewCount = reviewCountText ? parseInt(reviewCountText.replace(/[^\d]/g, '')) : undefined;

--- a/server/services/scraping/headParsers.ts
+++ b/server/services/scraping/headParsers.ts
@@ -13,7 +13,7 @@ export interface OgpData {
 }
 
 /** JSON-LD構造化データを抽出 */
-export function extractJsonLd($: cheerio.Root): Record<string, unknown> | null {
+export function extractJsonLd($: cheerio.CheerioAPI): Record<string, unknown> | null {
   try {
     const jsonLdScript = $('script[type="application/ld+json"]').html();
     if (jsonLdScript) {
@@ -26,7 +26,7 @@ export function extractJsonLd($: cheerio.Root): Record<string, unknown> | null {
 }
 
 /** OGPメタタグを一括抽出 */
-export function extractOgp($: cheerio.Root): OgpData {
+export function extractOgp($: cheerio.CheerioAPI): OgpData {
   return {
     title: $('meta[property="og:title"]').attr('content') || undefined,
     image: $('meta[property="og:image"]').attr('content') || undefined,

--- a/server/services/webScrapingService.ts
+++ b/server/services/webScrapingService.ts
@@ -100,7 +100,7 @@ export class WebScrapingService {
   /**
    * 製品名抽出（強化版）
    */
-  private extractName($: cheerio.Root, jsonLd: Record<string, unknown> | null, ogp: OgpData): string | undefined {
+  private extractName($: cheerio.CheerioAPI, jsonLd: Record<string, unknown> | null, ogp: OgpData): string | undefined {
     // JSON-LD構造化データから取得
     if (jsonLd?.name && typeof jsonLd.name === 'string') {
       return jsonLd.name;
@@ -132,7 +132,7 @@ export class WebScrapingService {
   /**
    * ブランド抽出（統合版）
    */
-  private extractBrand($: cheerio.Root, url: string, jsonLd: Record<string, unknown> | null, ogp: OgpData, name?: string): string | undefined {
+  private extractBrand($: cheerio.CheerioAPI, url: string, jsonLd: Record<string, unknown> | null, ogp: OgpData, name?: string): string | undefined {
     // JSON-LD構造化データから取得
     if (jsonLd?.brand) {
       const brand = jsonLd.brand as string | { name?: string };
@@ -174,7 +174,7 @@ export class WebScrapingService {
   /**
    * 価格抽出（強化版）
    */
-  private extractPrice($: cheerio.Root, jsonLd: Record<string, unknown> | null): number | undefined {
+  private extractPrice($: cheerio.CheerioAPI, jsonLd: Record<string, unknown> | null): number | undefined {
     // JSON-LD構造化データから取得
     if (jsonLd) {
       const offers = jsonLd.offers as Record<string, unknown> | undefined;
@@ -212,7 +212,7 @@ export class WebScrapingService {
   /**
    * 重量抽出（強化版）
    */
-  private extractWeight($: cheerio.Root): number | undefined {
+  private extractWeight($: cheerio.CheerioAPI): number | undefined {
     // より広範囲から重量を検索
     const searchSelectors = [
       '.product-description',
@@ -240,7 +240,7 @@ export class WebScrapingService {
   /**
    * 画像URL抽出（強化版）
    */
-  private extractImage($: cheerio.Root, baseUrl: string, jsonLd: Record<string, unknown> | null, ogp: OgpData): string | undefined {
+  private extractImage($: cheerio.CheerioAPI, baseUrl: string, jsonLd: Record<string, unknown> | null, ogp: OgpData): string | undefined {
     // JSON-LD構造化データから取得
     if (jsonLd?.image) {
       const image = jsonLd.image as string | string[];
@@ -305,7 +305,7 @@ export class WebScrapingService {
   /**
    * カテゴリ推測（強化版）
    */
-  private guessCategoryFromPage(name: string, $: cheerio.Root): string {
+  private guessCategoryFromPage(name: string, $: cheerio.CheerioAPI): string {
     // より関連性の高いテキストを優先
     const title = $('h1').text();
     const breadcrumbs = $('[class*="breadcrumb"]').text();

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -12,14 +12,17 @@
     "rootDir": "./",
     "declaration": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": [
     "**/*.ts"
   ],
   "exclude": [
     "node_modules",
-    "dist"
+    "dist",
+    "**/__tests__/**",
+    "**/*.test.ts"
   ]
 }
 


### PR DESCRIPTION
## Summary

DB 移行 (Cognito/Profile/Advisor) を完了し、STG 環境向けに自動デプロイ基盤を導入。

### 主な変更

**DB 移行 (P0 ロードマップ)**
- Cognito `sub` → `users.id` マッピング + プロビジョニング (`93d28be`)
- プロフィール DB 移行: migration 006 + profile route + `useProfile` (`cca6811`)
- Advisor 会話永続化: advisor route + `useAdvisorChat` (`02902b6`)

**自動デプロイ**
- Railway (バックエンド) + Vercel (フロントエンド) 分離構成 (`e732e20`)
- `railway.json` の `watchPatterns` / GitHub Actions の token 集約 / `docs/deploy.md` 追加 (`e0453ed`)

**UI / リファクタ**
- g/oz 単位切り替え UI 適用 (`e78aa6c`)
- タイポグラフィスケール 8 段階トークン化 (`9abc99d`)
- 任意値 `text-[Npx]` を canonical クラスに置換 (`d7a7a71`)
- CardGridView に上カバー画像追加 (`aa1e271`)
- Chart SummaryStatCard パディングトークン化 (`b707dc7`)

**テスト基盤**
- vitest + supertest 導入 + WP1/WP2/WP3 ユニットテスト 25 件 (`8175d48`, `b392ea0`)

## Test plan

- [ ] `npm run lint` 通過
- [ ] `npm run typecheck` 通過 (CI の continue-on-error に依存しないこと)
- [ ] `npm run build` 通過
- [ ] `npm run server:build` 通過 (Railway 用)
- [ ] ローカルで migration 006 を走らせ、プロフィール/Advisor が DB に永続化されることを確認
- [ ] Cognito 認証後、`users.id` が自動プロビジョニングされることを確認
- [ ] マージ後: Railway ダッシュボード設定 → 初回デプロイ成功を確認
- [ ] マージ後: Vercel に `VITE_API_BASE_URL` 設定 → Railway API と疎通確認
- [ ] `/api/health` が 200 を返す

## 注意事項

- マージ後の **Railway / Vercel / GitHub Secrets 設定** が必要 → 手順は [docs/deploy.md](docs/deploy.md) 参照
- 必要な GitHub Secrets: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
- `stg` GitHub environment 作成が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)