### PR TITLE
fix(server): migrate.ts の database ディレクトリ解決を修正

### DIFF
--- a/server/scripts/migrate.ts
+++ b/server/scripts/migrate.ts
@@ -24,12 +24,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // database ディレクトリの解決: tsx 実行時は ../database、tsc コンパイル後は ../../database
+// 本番 (コンパイル後) の ../database は dist/database/ になり JS のみで init.sql が無いので、
+// init.sql の存在でディレクトリを判定する
 function resolveDatabaseDir(): string {
   const candidates = [
     path.resolve(__dirname, '../database'),
     path.resolve(__dirname, '../../database'),
   ];
-  const found = candidates.find((p) => fs.existsSync(p));
+  const found = candidates.find((p) => fs.existsSync(path.join(p, 'init.sql')));
   if (!found) {
     throw new Error(`database directory not found. Checked: ${candidates.join(', ')}`);
   }


### PR DESCRIPTION
## Summary

Railway 本番デプロイで \`ENOENT: /app/server/dist/database/init.sql\` が出て起動失敗していた原因を解消。

## 問題

\`resolveDatabaseDir()\` が候補を \`fs.existsSync(p)\` で判定していたが、tsc コンパイル後の \`server/dist/database/\` は JS ファイルだけを含む別のディレクトリとして存在してしまい、init.sql が無いのに最初の候補として選ばれていた。

## 修正

\`fs.existsSync(path.join(p, 'init.sql'))\` で init.sql の存在を直接確認する形に変更。

## Test plan

- [x] \`npm run server:build\` 通過
- [ ] Railway 再デプロイで migrate が成功
- [ ] \`/api/health\` が 200 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)