### PR TITLE
feat: AIアドバイザー モダナイズ — Function Calling + SSE + Undo

### DIFF
--- a/client/components/GearAdvisorChat.tsx
+++ b/client/components/GearAdvisorChat.tsx
@@ -68,16 +68,17 @@ const GearRefChip: React.FC<{ ref_: GearRef; onClick: (gearId: string) => void }
   </button>
 );
 
-/** 編集提案カード */
+/** 編集提案カード（Apply + Undo 対応） */
 const SuggestedEditCard: React.FC<{
   edit: SuggestedEditWithState;
   editKey: string;
   applyingKey: string | null;
   onApply: () => void;
+  onUndo: () => void;
   weightUnit: 'g' | 'oz';
-}> = ({ edit, editKey, applyingKey, onApply, weightUnit }) => {
+}> = ({ edit, editKey, applyingKey, onApply, onUndo, weightUnit }) => {
   const isApplied = edit._applied === true;
-  const isApplying = applyingKey === editKey;
+  const isBusy = applyingKey === editKey;
 
   return (
     <div className={`p-3 rounded-xl mt-2 shadow-sm border text-xs
@@ -94,17 +95,38 @@ const SuggestedEditCard: React.FC<{
         <span className="font-medium">{formatEditValue(edit.field, edit.suggestedValue, weightUnit)}</span>
       </p>
       <p className="mb-2 text-gray-500 dark:text-gray-400">{edit.reason}</p>
-      <button
-        disabled={isApplied || isApplying}
-        onClick={onApply}
-        className={`w-full py-1.5 rounded-lg text-xs font-medium transition-opacity
-                    hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed
-                    ${isApplied
-                      ? 'bg-gray-300 dark:bg-gray-600 text-gray-600 dark:text-gray-300'
-                      : 'bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900'}`}
-      >
-        {isApplied ? 'Applied' : isApplying ? 'Applying…' : 'Apply change'}
-      </button>
+
+      {isApplied ? (
+        <div className="flex gap-2">
+          <span className="flex-1 py-1.5 rounded-lg text-xs font-medium text-center
+                           bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+            Applied
+          </span>
+          <button
+            type="button"
+            disabled={isBusy}
+            onClick={onUndo}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium
+                       text-gray-600 dark:text-gray-300
+                       border border-gray-300 dark:border-gray-600
+                       hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isBusy ? 'Undoing…' : 'Undo'}
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          disabled={isBusy}
+          onClick={onApply}
+          className="w-full py-1.5 rounded-lg text-xs font-medium transition-opacity
+                     hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed
+                     bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900"
+        >
+          {isBusy ? 'Applying…' : 'Apply change'}
+        </button>
+      )}
     </div>
   );
 };
@@ -123,10 +145,12 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
     input,
     setInput,
     isLoading,
+    isStreaming,
     applyingEdit,
     handleSend,
     sendText,
     handleApplyEdit,
+    handleUndoEdit,
   } = useAdvisorChat(gearContext, onApplyEdit);
 
   const { messagesEndRef, inputRef } = useAdvisorPanel(isOpen, messages);
@@ -140,6 +164,9 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
   const scopeLabel = gearContext.packName
     ? `Pack: ${gearContext.packName}`
     : `${gearContext.items.length} items`;
+
+  // 最後のアシスタントメッセージID（ストリーミングカーソル表示用）
+  const lastAssistantId = messages.filter((m) => m.role === 'assistant').at(-1)?.id;
 
   return (
     <>
@@ -197,11 +224,20 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
                                ${message.role === 'user'
                                  ? 'rounded-2xl rounded-br-sm bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900'
                                  : 'rounded-2xl rounded-bl-sm bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-gray-700'}`}>
-                <div className="whitespace-pre-wrap">{message.content}</div>
-                <div className={`text-2xs mt-1 opacity-50 select-none
-                                 ${message.role === 'user' ? 'text-right' : ''}`}>
-                  {TIME_FMT.format(message.timestamp)}
+                <div className="whitespace-pre-wrap">
+                  {message.content}
+                  {/* ストリーミング中のブリンクカーソル */}
+                  {isStreaming && message.id === lastAssistantId && (
+                    <span className="inline-block w-0.5 h-3.5 ml-0.5 bg-gray-500 dark:bg-gray-400 animate-pulse align-text-bottom" />
+                  )}
                 </div>
+                {/* タイムスタンプ（空メッセージのストリーミング中は非表示） */}
+                {message.content && (
+                  <div className={`text-2xs mt-1 opacity-50 select-none
+                                   ${message.role === 'user' ? 'text-right' : ''}`}>
+                    {TIME_FMT.format(message.timestamp)}
+                  </div>
+                )}
               </div>
 
               {/* Gear reference chips */}
@@ -223,6 +259,7 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
                       editKey={`${message.id}-${index}`}
                       applyingKey={applyingEdit}
                       onApply={() => handleApplyEdit(edit, message.id, index)}
+                      onUndo={() => handleUndoEdit(edit, message.id, index)}
                       weightUnit={weightUnit}
                     />
                   ))}
@@ -232,7 +269,8 @@ const GearAdvisorChat: React.FC<GearAdvisorChatProps> = ({
           </div>
         ))}
 
-        {isLoading && (
+        {/* 最初のトークン待ちスピナー（ストリーミング開始前のみ） */}
+        {isLoading && !isStreaming && (
           <div className="flex justify-start">
             <div className="p-3 rounded-2xl rounded-bl-sm flex items-center gap-2
                             bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 shadow-sm">

--- a/client/hooks/useAdvisorChat.ts
+++ b/client/hooks/useAdvisorChat.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { callAdvisor, AdvisorMessage, GearAdvisorContext, SuggestedEdit } from '../services/llmAdvisor';
-import type { GearRef } from '../services/llmAdvisor';
+import type { AdvisorMessage, GearAdvisorContext, SuggestedEdit, GearRef } from '../services/llmAdvisor';
+import { streamAdvisor } from '../services/llmAdvisorStream';
 import { useAuth } from '../utils/AuthContext';
 import {
   fetchLatestSession,
@@ -12,6 +12,7 @@ import {
 
 export interface SuggestedEditWithState extends SuggestedEdit {
   _applied?: boolean;
+  _previousValue?: unknown;
 }
 
 export interface ChatMessage {
@@ -54,6 +55,7 @@ const fromServerMessage = (row: AdvisorMessageRow): ChatMessage => ({
 /**
  * アドバイザーチャットの状態管理フック
  * 認証済みの場合は DB に会話を永続化。未認証時は従来の useState のみ。
+ * SSE ストリーミングでトークンを逐次表示。
  */
 export const useAdvisorChat = (
   gearContext: GearAdvisorContext,
@@ -63,11 +65,13 @@ export const useAdvisorChat = (
   const [messages, setMessages] = useState<ChatMessage[]>(() => [createInitialMessage()]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
   const [applyingEdit, setApplyingEdit] = useState<string | null>(null);
 
   // セッション ID（Lazy 作成: 最初のメッセージ送信時に作成）
   const sessionIdRef = useRef<string | null>(null);
   const initializedRef = useRef(false);
+  const abortRef = useRef<AbortController | null>(null);
 
   // sendText 内で最新の messages を参照するための ref
   const messagesRef = useRef(messages);
@@ -76,7 +80,6 @@ export const useAdvisorChat = (
   // --- 初期化: 認証済みなら最新セッションを復元 ---
   useEffect(() => {
     if (!isAuthenticated) {
-      // ログアウト遷移: セッションをリセット
       if (initializedRef.current) {
         sessionIdRef.current = null;
         setMessages([createInitialMessage()]);
@@ -91,7 +94,7 @@ export const useAdvisorChat = (
     const restore = async () => {
       try {
         const session = await fetchLatestSession();
-        if (!session) return; // セッションなし → lazy 作成待ち
+        if (!session) return;
 
         const serverMessages = await fetchMessages(session.id);
         if (serverMessages.length === 0) return;
@@ -103,14 +106,18 @@ export const useAdvisorChat = (
         ]);
       } catch (err) {
         console.error('[Advisor] セッション復元エラー:', err);
-        // 復元失敗時は initial greeting のまま
       }
     };
 
     void restore();
   }, [isAuthenticated]);
 
-  /** 指定テキストを送信する内部関数 */
+  // ストリーミング中断（パネルclose / unmount 時）
+  useEffect(() => {
+    return () => { abortRef.current?.abort(); };
+  }, []);
+
+  /** 指定テキストを送信する内部関数（SSEストリーミング） */
   const sendText = useCallback(async (text: string) => {
     if (!text || isLoading) return;
 
@@ -120,10 +127,12 @@ export const useAdvisorChat = (
       content: text,
       timestamp: new Date(),
     };
+    const assistantMsgId = createMessageId();
 
     setMessages((prev) => [...prev, userMsg]);
     setInput('');
     setIsLoading(true);
+    setIsStreaming(false);
 
     try {
       // 認証済みで未作成なら Lazy にセッション作成
@@ -133,7 +142,6 @@ export const useAdvisorChat = (
           sessionIdRef.current = session.id;
         } catch (err) {
           console.error('[Advisor] セッション作成失敗:', err);
-          // 失敗してもチャット自体は続行（次回送信時にリトライ）
         }
       }
 
@@ -151,40 +159,115 @@ export const useAdvisorChat = (
         userMsg,
       ].map((m) => ({ role: m.role, content: m.content }));
 
-      const result = await callAdvisor(history, gearContext);
-
-      const assistantMsg: ChatMessage = {
-        id: createMessageId(),
+      // プレースホルダーメッセージを追加
+      setMessages((prev) => [...prev, {
+        id: assistantMsgId,
         role: 'assistant',
-        content: result.message,
-        suggestedEdits: result.suggestedEdits,
-        gearRefs: result.gearRefs,
+        content: '',
         timestamp: new Date(),
+      }]);
+
+      // トークンバッチ用バッファ（rAF で描画頻度を最適化）
+      let tokenBuffer = '';
+      let rafId: number | null = null;
+      const flushTokens = () => {
+        if (!tokenBuffer) return;
+        const batch = tokenBuffer;
+        tokenBuffer = '';
+        setMessages((prev) =>
+          prev.map((m) => m.id === assistantMsgId ? { ...m, content: m.content + batch } : m)
+        );
       };
 
-      setMessages((prev) => [...prev, assistantMsg]);
+      // AbortController
+      abortRef.current = new AbortController();
 
-      // アシスタントメッセージを DB に保存 (fire-and-forget)
-      if (isAuthenticated && sessionIdRef.current) {
-        void saveMessage(sessionIdRef.current, {
-          role: 'assistant',
-          content: result.message,
-          suggestedEdits: result.suggestedEdits,
-          gearRefs: result.gearRefs,
-        }).catch((err) => console.error('[Advisor] メッセージ保存失敗:', err));
-      }
+      await streamAdvisor(history, gearContext, {
+        onToken: (tokenText) => {
+          if (!isStreaming) setIsStreaming(true);
+          tokenBuffer += tokenText;
+          if (rafId === null) {
+            rafId = requestAnimationFrame(() => {
+              flushTokens();
+              rafId = null;
+            });
+          }
+        },
+        onTool: (name, data) => {
+          // バッファ内の残りトークンをフラッシュ
+          if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+          flushTokens();
+
+          if (name === 'reference_gear') {
+            setMessages((prev) =>
+              prev.map((m) => m.id === assistantMsgId
+                ? { ...m, gearRefs: [...(m.gearRefs ?? []), ...(data as GearRef[])] }
+                : m
+              )
+            );
+          } else if (name === 'suggest_edits') {
+            setMessages((prev) =>
+              prev.map((m) => m.id === assistantMsgId
+                ? { ...m, suggestedEdits: [...(m.suggestedEdits ?? []), ...(data as SuggestedEditWithState[])] }
+                : m
+              )
+            );
+          }
+        },
+        onDone: () => {
+          // 残りトークンフラッシュ
+          if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+          flushTokens();
+
+          // DB に保存 (fire-and-forget)
+          if (isAuthenticated && sessionIdRef.current) {
+            setMessages((prev) => {
+              const finalMsg = prev.find((m) => m.id === assistantMsgId);
+              if (finalMsg) {
+                void saveMessage(sessionIdRef.current!, {
+                  role: 'assistant',
+                  content: finalMsg.content,
+                  suggestedEdits: finalMsg.suggestedEdits,
+                  gearRefs: finalMsg.gearRefs,
+                }).catch((err) => console.error('[Advisor] メッセージ保存失敗:', err));
+              }
+              return prev;
+            });
+          }
+        },
+        onError: (err) => {
+          if (rafId !== null) { cancelAnimationFrame(rafId); rafId = null; }
+          setMessages((prev) =>
+            prev.map((m) => m.id === assistantMsgId
+              ? { ...m, content: m.content || `Something went wrong: ${err.message}` }
+              : m
+            )
+          );
+        },
+      }, abortRef.current.signal);
     } catch (error) {
-      setMessages((prev) => [
-        ...prev,
-        {
+      // AbortError は無視（ユーザーによるキャンセル）
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+
+      setMessages((prev) => {
+        const hasPlaceholder = prev.some((m) => m.id === assistantMsgId);
+        if (hasPlaceholder) {
+          return prev.map((m) => m.id === assistantMsgId
+            ? { ...m, content: `Something went wrong: ${error instanceof Error ? error.message : 'Unknown error'}` }
+            : m
+          );
+        }
+        return [...prev, {
           id: createMessageId(),
           role: 'assistant',
           content: `Something went wrong: ${error instanceof Error ? error.message : 'Unknown error'}`,
           timestamp: new Date(),
-        },
-      ]);
+        }];
+      });
     } finally {
       setIsLoading(false);
+      setIsStreaming(false);
+      abortRef.current = null;
     }
   }, [isLoading, gearContext, isAuthenticated]);
 
@@ -206,7 +289,33 @@ export const useAdvisorChat = (
               ? {
                   ...msg,
                   suggestedEdits: msg.suggestedEdits.map((e, i) =>
-                    i === editIndex ? { ...e, _applied: true } : e
+                    i === editIndex ? { ...e, _applied: true, _previousValue: e.currentValue } : e
+                  ),
+                }
+              : msg
+          )
+        );
+      } finally {
+        setApplyingEdit(null);
+      }
+    },
+    [onApplyEdit]
+  );
+
+  const handleUndoEdit = useCallback(
+    async (edit: SuggestedEditWithState, messageId: string, editIndex: number) => {
+      if (!edit._applied || edit._previousValue === undefined) return;
+      const key = `${messageId}-${editIndex}`;
+      setApplyingEdit(key);
+      try {
+        await onApplyEdit(edit.gearId, edit.field, edit._previousValue);
+        setMessages((prev) =>
+          prev.map((msg) =>
+            msg.id === messageId && msg.suggestedEdits
+              ? {
+                  ...msg,
+                  suggestedEdits: msg.suggestedEdits.map((e, i) =>
+                    i === editIndex ? { ...e, _applied: false, _previousValue: undefined } : e
                   ),
                 }
               : msg
@@ -224,10 +333,12 @@ export const useAdvisorChat = (
     input,
     setInput,
     isLoading,
+    isStreaming,
     applyingEdit,
     handleSend,
     sendText,
     handleApplyEdit,
+    handleUndoEdit,
   };
 };
 

--- a/client/services/llmAdvisorStream.ts
+++ b/client/services/llmAdvisorStream.ts
@@ -1,0 +1,123 @@
+/**
+ * SSE ストリーミング版アドバイザー API クライアント
+ * fetch + ReadableStream で SSE をパース（EventSource は POST 非対応のため不使用）
+ */
+import { API_CONFIG, getHeaders } from './api.client';
+import type { AdvisorMessage, GearAdvisorContext, GearRef, SuggestedEdit } from './llmAdvisor';
+
+export interface StreamCallbacks {
+  onToken: (text: string) => void;
+  onTool: (name: string, data: GearRef[] | SuggestedEdit[]) => void;
+  onDone: () => void;
+  onError: (error: Error) => void;
+}
+
+/**
+ * SSE でアドバイザーにストリーミングリクエストを送信
+ * フォールバック（JSON応答）にも対応
+ */
+export async function streamAdvisor(
+  conversation: AdvisorMessage[],
+  gearContext: GearAdvisorContext,
+  callbacks: StreamCallbacks,
+  signal?: AbortSignal,
+): Promise<void> {
+  const url = `${API_CONFIG.baseUrl}/llm/advisor/stream`;
+  const headers = await getHeaders();
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ conversation, gearContext }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => 'Unknown error');
+    callbacks.onError(new Error(`HTTP ${response.status}: ${text}`));
+    return;
+  }
+
+  // フォールバック: Content-Type が JSON なら非ストリーミング応答
+  const contentType = response.headers.get('Content-Type') ?? '';
+  if (contentType.includes('application/json')) {
+    const json = await response.json();
+    if (json.success && json.data) {
+      callbacks.onToken(json.data.message);
+      if (json.data.gearRefs?.length > 0) {
+        callbacks.onTool('reference_gear', json.data.gearRefs);
+      }
+      if (json.data.suggestedEdits?.length > 0) {
+        callbacks.onTool('suggest_edits', json.data.suggestedEdits);
+      }
+      callbacks.onDone();
+    } else {
+      callbacks.onError(new Error(json.message || 'Unknown error'));
+    }
+    return;
+  }
+
+  // SSE ストリーミング応答
+  if (!response.body) {
+    callbacks.onError(new Error('No response body'));
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    let reading = true;
+    while (reading) {
+      const { done, value } = await reader.read();
+      if (done) { reading = false; continue; }
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE イベントをパース（\n\n で区切り）
+      const parts = buffer.split('\n\n');
+      buffer = parts.pop() ?? '';
+
+      for (const part of parts) {
+        if (!part.trim()) continue;
+
+        let eventType = '';
+        let data = '';
+
+        for (const line of part.split('\n')) {
+          if (line.startsWith('event: ')) {
+            eventType = line.slice(7).trim();
+          } else if (line.startsWith('data: ')) {
+            data = line.slice(6);
+          }
+        }
+
+        if (!data) continue;
+
+        try {
+          const parsed = JSON.parse(data);
+
+          switch (eventType) {
+            case 'token':
+              callbacks.onToken(parsed.text);
+              break;
+            case 'tool':
+              callbacks.onTool(parsed.name, parsed.data);
+              break;
+            case 'done':
+              callbacks.onDone();
+              break;
+            case 'error':
+              callbacks.onError(new Error(parsed.message));
+              break;
+          }
+        } catch {
+          // 不正な JSON は無視
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/server/routes/llm.ts
+++ b/server/routes/llm.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { handleExtractUrl, handleExtractPrompt, handleEnhancePrompt } from './llm/extractHandlers.js';
 import { handleExtractCategory } from './llm/categoryHandlers.js';
 import { handleHealthCheck } from './llm/healthHandlers.js';
-import { handleAdvisorChat } from './llm/advisorHandlers.js';
+import { handleAdvisorChat, handleAdvisorChatStream } from './llm/advisorHandlers.js';
 
 const router = Router();
 
@@ -16,6 +16,7 @@ router.post('/extract-category', handleExtractCategory);
 
 // Advisor endpoints
 router.post('/advisor', handleAdvisorChat);
+router.post('/advisor/stream', handleAdvisorChatStream);
 
 // Health endpoint
 router.get('/health', handleHealthCheck);

--- a/server/routes/llm/advisorHandlers.ts
+++ b/server/routes/llm/advisorHandlers.ts
@@ -5,9 +5,8 @@ import type {
   AdvisorRequestBody,
   AdvisorResponseData,
   GearContext,
-  GearRef,
-  SuggestedEdit,
 } from './advisorTypes.js';
+import { ADVISOR_TOOLS, parseToolCalls } from './advisorTools.js';
 
 // ==================== バリデーション ====================
 
@@ -60,18 +59,11 @@ const buildSystemPrompt = (ctx: GearContext): string => {
     ...gearLines,
     '--- ここまで ---',
     '',
-    '## 回答フォーマット',
-    '必ず以下のJSONのみを返してください（コードブロック不要）:',
-    '{',
-    '  "message": "アドバイスのメッセージ（改行は\\nで表現）",',
-    '  "gearRefs": [{ "gearId": "IDをそのまま", "gearName": "ギア名" }],',
-    '  "suggestedEdits": [',
-    '    { "gearId": "ID", "gearName": "名前", "field": "weightGrams|priceCents|isInKit|weightClass", "currentValue": 現在値, "suggestedValue": 提案値, "reason": "理由" }',
-    '  ]',
-    '}',
-    '',
-    'gearRefs: メッセージで具体的に言及したギアのID/名前（最大5件、不要なら空配列）',
-    'suggestedEdits: 実際に数値・状態の変更を提案する場合のみ含める（不要なら空配列）',
+    '## 回答ルール',
+    '- 自然な文章でアドバイスを提供してください',
+    '- ギアを具体的に言及する場合は reference_gear ツールを呼んでください（最大5件）',
+    '- 重量・価格・キット状態・重量クラスの変更を提案する場合は suggest_edits ツールを呼んでください',
+    '- ツール呼び出しは任意です。情報のみの返答ではツール呼び出し不要です',
   ]
     .filter((line) => line !== null)
     .join('\n');
@@ -99,46 +91,24 @@ const buildFallbackResponse = (ctx: GearContext): AdvisorResponseData => {
   return { message: lines, gearRefs: [], suggestedEdits: [] };
 };
 
-// ==================== JSONパース ====================
+// ==================== バリデーションヘルパー（ストリーミングハンドラーと共有） ====================
 
-const parseAdvisorResponse = (raw: string): AdvisorResponseData => {
-  // JSONコードブロックを除去してからパース
-  const cleaned = raw.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '').trim();
+export const validateAdvisorRequest = (
+  body: AdvisorRequestBody,
+): { conversation: AdvisorMessage[]; gearContext: GearContext } | { error: string } => {
+  const { conversation, gearContext } = body;
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(cleaned);
-  } catch {
-    // JSON抽出を試みる
-    const match = cleaned.match(/\{[\s\S]*\}/);
-    if (!match) throw new Error('JSON not found in response');
-    parsed = JSON.parse(match[0]);
+  if (!Array.isArray(conversation) || conversation.length === 0) {
+    return { error: 'conversation（非空配列）は必須です' };
+  }
+  if (!conversation.every(isAdvisorMessage)) {
+    return { error: '各メッセージには role ("user"|"assistant") と content (string) が必要です' };
+  }
+  if (!isGearContext(gearContext)) {
+    return { error: 'gearContext.items（配列）は必須です' };
   }
 
-  if (!parsed || typeof parsed !== 'object') {
-    throw new Error('Invalid response structure');
-  }
-
-  const obj = parsed as Record<string, unknown>;
-
-  return {
-    message: typeof obj.message === 'string' ? obj.message : '回答を生成できませんでした。',
-    gearRefs: Array.isArray(obj.gearRefs)
-      ? obj.gearRefs.filter(
-          (r): r is GearRef =>
-            r != null && typeof r === 'object' &&
-            typeof (r as GearRef).gearId === 'string' &&
-            typeof (r as GearRef).gearName === 'string'
-        )
-      : [],
-    suggestedEdits: Array.isArray(obj.suggestedEdits)
-      ? obj.suggestedEdits.filter(
-          (e): e is SuggestedEdit =>
-            e != null && typeof e === 'object' &&
-            typeof (e as SuggestedEdit).gearId === 'string'
-        )
-      : [],
-  };
+  return { conversation: conversation as AdvisorMessage[], gearContext: gearContext as GearContext };
 };
 
 // ==================== ハンドラー ====================
@@ -148,29 +118,12 @@ const parseAdvisorResponse = (raw: string): AdvisorResponseData => {
  * ギアアドバイザーとの多ターン会話
  */
 export const handleAdvisorChat = async (req: Request, res: Response) => {
-  const { conversation, gearContext } = req.body as AdvisorRequestBody;
-
-  // バリデーション
-  if (!Array.isArray(conversation) || conversation.length === 0) {
-    return res.status(400).json({
-      success: false,
-      message: 'conversation（非空配列）は必須です',
-    });
+  const validated = validateAdvisorRequest(req.body as AdvisorRequestBody);
+  if ('error' in validated) {
+    return res.status(400).json({ success: false, message: validated.error });
   }
 
-  if (!conversation.every(isAdvisorMessage)) {
-    return res.status(400).json({
-      success: false,
-      message: '各メッセージには role ("user"|"assistant") と content (string) が必要です',
-    });
-  }
-
-  if (!isGearContext(gearContext)) {
-    return res.status(400).json({
-      success: false,
-      message: 'gearContext.items（配列）は必須です',
-    });
-  }
+  const { conversation, gearContext } = validated;
 
   // OpenAI 非利用時はフォールバック
   if (!openaiClient.isAvailable()) {
@@ -184,15 +137,17 @@ export const handleAdvisorChat = async (req: Request, res: Response) => {
 
   try {
     const systemPrompt = buildSystemPrompt(gearContext);
-    console.log(`[Advisor] Calling OpenAI (${conversation.length} messages, ${gearContext.items.length} gear items)`);
+    console.log(`[Advisor] Calling OpenAI with tools (${conversation.length} messages, ${gearContext.items.length} gear items)`);
 
-    const raw = await openaiClient.chatWithHistory(systemPrompt, conversation, 1500);
-    const data = parseAdvisorResponse(raw);
+    const completion = await openaiClient.chatWithTools(systemPrompt, conversation, ADVISOR_TOOLS, 1500);
+    const choice = completion.choices[0];
+    const message = choice?.message?.content ?? '回答を生成できませんでした。';
+    const { gearRefs, suggestedEdits } = parseToolCalls(choice?.message?.tool_calls);
+    const data: AdvisorResponseData = { message, gearRefs, suggestedEdits };
 
     return res.json({ success: true, data, message: 'Advisor response generated' });
   } catch (error) {
     console.error('[Advisor] OpenAI call failed:', error);
-    // API呼び出し失敗時もフォールバックを返す（500にせずUXを維持）
     return res.json({
       success: true,
       data: {
@@ -201,5 +156,123 @@ export const handleAdvisorChat = async (req: Request, res: Response) => {
       },
       message: 'Fallback response (API error)',
     });
+  }
+};
+
+// ==================== SSE ストリーミングハンドラー ====================
+
+/** SSE イベントを書き込むヘルパー */
+const sendSSE = (res: Response, event: string, data: unknown) => {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+};
+
+/**
+ * POST /api/v1/llm/advisor/stream
+ * SSE でトークンを逐次送信するストリーミング版アドバイザー
+ */
+export const handleAdvisorChatStream = async (req: Request, res: Response) => {
+  const validated = validateAdvisorRequest(req.body as AdvisorRequestBody);
+  if ('error' in validated) {
+    return res.status(400).json({ success: false, message: validated.error });
+  }
+
+  const { conversation, gearContext } = validated;
+
+  // OpenAI 非利用時は通常JSONレスポンスにフォールバック（SSEヘッダーを書かない）
+  if (!openaiClient.isAvailable()) {
+    return res.json({
+      success: true,
+      data: buildFallbackResponse(gearContext),
+      message: 'Fallback response (no API key)',
+    });
+  }
+
+  // SSE ヘッダー設定
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+
+  let aborted = false;
+  req.on('close', () => { aborted = true; });
+
+  try {
+    const systemPrompt = buildSystemPrompt(gearContext);
+    console.log(`[Advisor/Stream] Calling OpenAI (${conversation.length} messages, ${gearContext.items.length} gear items)`);
+
+    const stream = await openaiClient.chatWithToolsStream(systemPrompt, conversation, ADVISOR_TOOLS, 1500);
+
+    // tool_calls の引数を手動蓄積
+    const toolCallBuffers: Map<number, { name: string; arguments: string }> = new Map();
+
+    for await (const chunk of stream) {
+      if (aborted) break;
+
+      const delta = chunk.choices[0]?.delta;
+      if (!delta) continue;
+
+      // テキストコンテンツ → token イベントで即送信
+      if (delta.content) {
+        sendSSE(res, 'token', { text: delta.content });
+      }
+
+      // tool_calls delta → バッファに蓄積
+      if (delta.tool_calls) {
+        for (const tc of delta.tool_calls) {
+          const existing = toolCallBuffers.get(tc.index);
+          if (existing) {
+            existing.arguments += tc.function?.arguments ?? '';
+          } else {
+            toolCallBuffers.set(tc.index, {
+              name: tc.function?.name ?? '',
+              arguments: tc.function?.arguments ?? '',
+            });
+          }
+        }
+      }
+    }
+
+    if (aborted) {
+      res.end();
+      return;
+    }
+
+    // ストリーム完了: 蓄積したtool_callsをパースして送信
+    if (toolCallBuffers.size > 0) {
+      const toolCalls = Array.from(toolCallBuffers.values()).map((buf, i) => ({
+        id: `call_${i}`,
+        type: 'function' as const,
+        function: { name: buf.name, arguments: buf.arguments },
+      }));
+      const { gearRefs, suggestedEdits } = parseToolCalls(toolCalls);
+
+      if (gearRefs.length > 0) {
+        sendSSE(res, 'tool', { name: 'reference_gear', data: gearRefs });
+      }
+      if (suggestedEdits.length > 0) {
+        sendSSE(res, 'tool', { name: 'suggest_edits', data: suggestedEdits });
+      }
+    }
+
+    sendSSE(res, 'done', {});
+    res.end();
+  } catch (error) {
+    console.error('[Advisor/Stream] OpenAI call failed:', error);
+    if (!res.headersSent) {
+      // ヘッダー未送信ならJSONフォールバック
+      return res.json({
+        success: true,
+        data: {
+          ...buildFallbackResponse(gearContext),
+          message: `The AI request failed. Please try again in a moment.\n\n${error instanceof Error ? error.message : 'Unknown error'}`,
+        },
+        message: 'Fallback response (API error)',
+      });
+    }
+    // SSE送信中のエラー
+    sendSSE(res, 'error', { message: error instanceof Error ? error.message : 'Unknown error' });
+    res.end();
   }
 };

--- a/server/routes/llm/advisorTools.ts
+++ b/server/routes/llm/advisorTools.ts
@@ -1,0 +1,128 @@
+/**
+ * OpenAI Function Calling 用ツール定義 + パーサー
+ * アドバイザーが gearRefs / suggestedEdits を返す際に使用
+ */
+import type { ChatCompletionTool, ChatCompletionMessageToolCall } from 'openai/resources/chat/completions';
+import type { GearRef, SuggestedEdit } from './advisorTypes.js';
+
+// ==================== ツール定義 ====================
+
+export const ADVISOR_TOOLS: ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'reference_gear',
+      description: 'メッセージで具体的に言及したギアを参照する。1回の呼び出しで全参照をまとめて渡す。',
+      parameters: {
+        type: 'object',
+        properties: {
+          refs: {
+            type: 'array',
+            description: '参照するギア（最大5件）',
+            items: {
+              type: 'object',
+              properties: {
+                gearId: { type: 'string', description: 'ギアリストのID' },
+                gearName: { type: 'string', description: 'ギア名' },
+              },
+              required: ['gearId', 'gearName'],
+            },
+            maxItems: 5,
+          },
+        },
+        required: ['refs'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'suggest_edits',
+      description: 'ギアの重量・価格・キット状態・重量クラスの変更を提案する。1回の呼び出しで全提案をまとめて渡す。',
+      parameters: {
+        type: 'object',
+        properties: {
+          edits: {
+            type: 'array',
+            description: '提案する編集リスト',
+            items: {
+              type: 'object',
+              properties: {
+                gearId: { type: 'string', description: 'ギアID' },
+                gearName: { type: 'string', description: 'ギア名' },
+                field: {
+                  type: 'string',
+                  enum: ['weightGrams', 'priceCents', 'isInKit', 'weightClass'],
+                  description: '編集対象フィールド',
+                },
+                currentValue: { description: '現在の値' },
+                suggestedValue: { description: '提案する新しい値' },
+                reason: { type: 'string', description: '変更の理由' },
+              },
+              required: ['gearId', 'gearName', 'field', 'currentValue', 'suggestedValue', 'reason'],
+            },
+          },
+        },
+        required: ['edits'],
+      },
+    },
+  },
+];
+
+// ==================== ツール呼び出しパーサー ====================
+
+/**
+ * OpenAI の tool_calls 配列から gearRefs / suggestedEdits を抽出
+ */
+export function parseToolCalls(
+  toolCalls: ChatCompletionMessageToolCall[] | undefined,
+): { gearRefs: GearRef[]; suggestedEdits: SuggestedEdit[] } {
+  const gearRefs: GearRef[] = [];
+  const suggestedEdits: SuggestedEdit[] = [];
+
+  if (!toolCalls) return { gearRefs, suggestedEdits };
+
+  for (const call of toolCalls) {
+    if (call.type !== 'function') continue;
+
+    let args: unknown;
+    try {
+      args = JSON.parse(call.function.arguments);
+    } catch {
+      console.warn(`[AdvisorTools] JSON parse failed for ${call.function.name}:`, call.function.arguments);
+      continue;
+    }
+
+    if (call.function.name === 'reference_gear') {
+      const obj = args as { refs?: unknown[] };
+      if (Array.isArray(obj.refs)) {
+        for (const ref of obj.refs) {
+          if (
+            ref && typeof ref === 'object' &&
+            typeof (ref as GearRef).gearId === 'string' &&
+            typeof (ref as GearRef).gearName === 'string'
+          ) {
+            gearRefs.push({ gearId: (ref as GearRef).gearId, gearName: (ref as GearRef).gearName });
+          }
+        }
+      }
+    } else if (call.function.name === 'suggest_edits') {
+      const obj = args as { edits?: unknown[] };
+      if (Array.isArray(obj.edits)) {
+        for (const edit of obj.edits) {
+          if (
+            edit && typeof edit === 'object' &&
+            typeof (edit as SuggestedEdit).gearId === 'string' &&
+            typeof (edit as SuggestedEdit).gearName === 'string' &&
+            typeof (edit as SuggestedEdit).field === 'string' &&
+            typeof (edit as SuggestedEdit).reason === 'string'
+          ) {
+            suggestedEdits.push(edit as SuggestedEdit);
+          }
+        }
+      }
+    }
+  }
+
+  return { gearRefs, suggestedEdits };
+}

--- a/server/services/openaiClient.ts
+++ b/server/services/openaiClient.ts
@@ -1,4 +1,6 @@
 import OpenAI from 'openai';
+import type { ChatCompletion, ChatCompletionChunk, ChatCompletionTool } from 'openai/resources/chat/completions';
+import type { Stream } from 'openai/streaming';
 
 /**
  * シンプルなOpenAI Client
@@ -76,6 +78,61 @@ export class OpenAIClient {
     }
 
     return content;
+  }
+
+  /**
+   * ツール付きチャート完了API呼び出し（Function Calling）
+   */
+  async chatWithTools(
+    systemPrompt: string,
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+    tools: ChatCompletionTool[],
+    maxTokens = 1500,
+  ): Promise<ChatCompletion> {
+    if (!this.openai) {
+      throw new Error('OpenAI client not available');
+    }
+
+    return this.openai.chat.completions.create({
+      model: this.defaultModel,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        ...messages,
+      ],
+      tools,
+      tool_choice: 'auto',
+      parallel_tool_calls: true,
+      temperature: 0.3,
+      max_tokens: maxTokens,
+    });
+  }
+
+  /**
+   * ツール付きストリーミングAPI呼び出し（SSE用）
+   */
+  chatWithToolsStream(
+    systemPrompt: string,
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>,
+    tools: ChatCompletionTool[],
+    maxTokens = 1500,
+  ): Promise<Stream<ChatCompletionChunk>> {
+    if (!this.openai) {
+      throw new Error('OpenAI client not available');
+    }
+
+    return this.openai.chat.completions.create({
+      model: this.defaultModel,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        ...messages,
+      ],
+      tools,
+      tool_choice: 'auto',
+      parallel_tool_calls: true,
+      temperature: 0.3,
+      max_tokens: maxTokens,
+      stream: true,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- OpenAI Function Calling に移行（JSON強制プロンプト → Tool Use API で型安全に）
- SSE ストリーミングでトークン逐次表示（スピナー → ブリンクカーソル + テキスト流れ込み）
- Suggested Edits に Undo 機能追加（適用済み提案を1クリックで復元）

## 変更ファイル

### サーバー
- `server/routes/llm/advisorTools.ts` — 新規: ツール定義 + parseToolCalls
- `server/services/openaiClient.ts` — chatWithTools / chatWithToolsStream 追加
- `server/routes/llm/advisorHandlers.ts` — Function Calling 対応 + SSE ハンドラー追加
- `server/routes/llm.ts` — POST /advisor/stream ルート追加

### クライアント
- `client/services/llmAdvisorStream.ts` — 新規: SSE パーサー
- `client/hooks/useAdvisorChat.ts` — ストリーミング対応 + Undo + rAF バッチ最適化
- `client/components/GearAdvisorChat.tsx` — ブリンクカーソル + Undo ボタン UI

## Test plan
- [ ] OPENAI_API_KEY 設定済みでアドバイザーに質問 → テキストがトークン単位で流れること
- [ ] gearRefs チップ / suggestedEdit カードがストリーム完了後に表示されること
- [ ] Apply → Undo → 値が元に戻ること
- [ ] API key未設定 → フォールバック応答が返ること
- [ ] チャットパネルを閉じる → ストリーム中断されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)