### PR TITLE
fix(ui): 通知タイポ修正 + ErrorBoundary 追加 (PR1)

### DIFF
--- a/client/components/ErrorBoundary.tsx
+++ b/client/components/ErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { COLORS, SPACING_SCALE, COMPONENT_RADIUS } from '../utils/designSystem';
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * アプリケーション全体の例外を捕捉して白画面を防ぐエラー境界。
+ * React のレンダー/ライフサイクル中に throw された例外のみ捕捉する。
+ * イベントハンドラや非同期処理の例外は捕捉しない（各呼び出し側で try/catch が必要）。
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[ErrorBoundary]', error, info);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback;
+    }
+
+    return (
+      <div
+        role="alert"
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: SPACING_SCALE.lg,
+          backgroundColor: COLORS.background,
+          color: COLORS.text.primary,
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 480,
+            width: '100%',
+            padding: SPACING_SCALE['2xl'],
+            backgroundColor: COLORS.surface,
+            borderRadius: COMPONENT_RADIUS.surface,
+            borderLeft: `4px solid ${COLORS.error}`,
+          }}
+        >
+          <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: SPACING_SCALE.md }}>
+            予期しないエラーが発生しました
+          </h1>
+          <p style={{ fontSize: 14, color: COLORS.text.secondary, marginBottom: SPACING_SCALE.lg }}>
+            画面の再読み込みで復旧する場合があります。問題が続く場合は管理者にお問い合わせください。
+          </p>
+          {this.state.error?.message && (
+            <pre
+              style={{
+                fontSize: 12,
+                color: COLORS.text.muted,
+                backgroundColor: COLORS.gray[100],
+                padding: SPACING_SCALE.md,
+                borderRadius: COMPONENT_RADIUS.control,
+                marginBottom: SPACING_SCALE.lg,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+              }}
+            >
+              {this.state.error.message}
+            </pre>
+          )}
+          <button
+            type="button"
+            onClick={this.handleReload}
+            style={{
+              padding: `${SPACING_SCALE.sm}px ${SPACING_SCALE.lg}px`,
+              backgroundColor: COLORS.accent.primary,
+              color: COLORS.white,
+              borderRadius: COMPONENT_RADIUS.control,
+              fontSize: 14,
+              fontWeight: 600,
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            画面を再読み込み
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/client/components/NotificationPopup.tsx
+++ b/client/components/NotificationPopup.tsx
@@ -84,8 +84,8 @@ const NotificationPopup: React.FC<NotificationPopupProps> = ({ messages, onRemov
             key={message.id}
             className={`p-4 transition-all duration-300 transform ${
               isAnimatingOut
-                ? 'trangray-x-full opacity-0'
-                : 'trangray-x-0 opacity-100'
+                ? 'translate-x-full opacity-0'
+                : 'translate-x-0 opacity-100'
             } ${
               message.type === 'loading' ? 'animate-pulse' : ''
             }`}

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import './styles/globals.css'
 import { themeCssVariables } from './styles/tokens'
 import App from './components/App'
+import ErrorBoundary from './components/ErrorBoundary'
 import { AuthProvider } from './utils/AuthContext'
 import { WeightUnitProvider } from './contexts/WeightUnitContext'
 import { CurrencyProvider } from './contexts/CurrencyContext'
@@ -43,14 +44,16 @@ observer.observe(document.documentElement, { attributes: true, attributeFilter: 
 
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <WeightUnitProvider>
-          <CurrencyProvider>
-            <App />
-          </CurrencyProvider>
-        </WeightUnitProvider>
-      </AuthProvider>
-    </BrowserRouter>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <AuthProvider>
+          <WeightUnitProvider>
+            <CurrencyProvider>
+              <App />
+            </CurrencyProvider>
+          </WeightUnitProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 )


### PR DESCRIPTION
## 概要
Issue #41 の PR1。軽微な品質/信頼性修正をまとめる。

## 変更内容
- **通知ポップアップのタイポ修正**: `NotificationPopup.tsx` で無効なクラス `trangray-x-full` / `trangray-x-0` を正しい `translate-x-full` / `translate-x-0` に修正。これまで退出アニメーションが効かず通知がパッと消えていた
- **ErrorBoundary の追加**: 新規コンポーネント `client/components/ErrorBoundary.tsx` を `main.tsx` のルートに適用。レンダーエラー時の白画面を防ぎ、日本語のフォールバックUIと再読み込みボタンを表示

## テスト計画
- [ ] `npm run typecheck` パス（確認済み）
- [ ] `npm run build` パス（確認済み）
- [ ] 通知表示 → 退出時にスライドアウトすること
- [ ] 任意のコンポーネントで意図的に throw してフォールバックUIが出ること

refs #41

https://claude.ai/code/session_01Xnaq8vpBRrDvwHWVydfFs7
