### PR TITLE
feat(ui): 重量単位(g/oz)トグルを全UIに適用 (PR2)

### DIFF
--- a/client/components/BulkActionModal.tsx
+++ b/client/components/BulkActionModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Category } from '../utils/types';
 import { STATUS_TONES } from '../utils/designSystem';
+import { useWeightUnit } from '../contexts/WeightUnitContext';
+import { convertToGrams } from '../utils/weightUnit';
 import SeasonBar from './SeasonBar';
 
 interface BulkActionModalProps {
@@ -21,6 +23,7 @@ const BulkActionModal: React.FC<BulkActionModalProps> = ({
   onBulkDelete
 }) => {
   const errorTone = STATUS_TONES.error;
+  const { unit } = useWeightUnit();
 
   const [action, setAction] = useState<'update' | 'delete'>('update');
   const [updateField, setUpdateField] = useState<'category' | 'priority' | 'owned' | 'required' | 'seasons' | 'weight' | 'price'>('category');
@@ -58,9 +61,11 @@ const BulkActionModal: React.FC<BulkActionModalProps> = ({
         case 'seasons':
           data.seasons = selectedSeasons;
           break;
-        case 'weight':
-          data.weightGrams = parseInt(updateValue);
+        case 'weight': {
+          const num = parseFloat(updateValue);
+          data.weightGrams = isNaN(num) ? undefined : convertToGrams(num, unit);
           break;
+        }
         case 'price':
           data.priceCents = parseInt(updateValue);
           break;
@@ -198,10 +203,11 @@ const BulkActionModal: React.FC<BulkActionModalProps> = ({
                   <input
                     type="number"
                     min="0"
+                    step={unit === 'oz' ? 0.1 : 1}
                     value={updateValue}
                     onChange={(e) => setUpdateValue(e.target.value)}
                     className="input w-full"
-                    placeholder="Weight (grams)"
+                    placeholder={`Weight (${unit})`}
                     required
                   />
                 ) : updateField === 'price' ? (

--- a/client/components/DetailPanel/CategorySummaryView.tsx
+++ b/client/components/DetailPanel/CategorySummaryView.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { GearItemWithCalculated, QuantityDisplayMode } from '../../utils/types';
 import { COLORS } from '../../utils/designSystem';
 import { formatPrice } from '../../utils/formatters';
+import { formatWeight } from '../../utils/weightUnit';
+import { useWeightUnit } from '../../contexts/WeightUnitContext';
 import ItemListCard from './ItemListCard';
 import { getQuantityForDisplayMode } from '../../utils/chartHelpers';
 import CategoryBadge from '../ui/CategoryBadge';
@@ -21,6 +23,7 @@ const CategorySummaryView: React.FC<CategorySummaryViewProps> = ({
   onItemClick,
   quantityDisplayMode,
 }) => {
+  const { unit } = useWeightUnit();
   const getItemValue = (item: GearItemWithCalculated) => {
     const quantity = getQuantityForDisplayMode(item, quantityDisplayMode);
     return viewMode === 'cost'
@@ -84,7 +87,7 @@ const CategorySummaryView: React.FC<CategorySummaryViewProps> = ({
         <div className="space-y-2 text-xs">
           <div className="flex justify-between items-center">
             <span className="text-gray-600">Weight:</span>
-            <span className="font-semibold text-gray-900">{stats.totalWeight}g</span>
+            <span className="font-semibold text-gray-900">{formatWeight(stats.totalWeight, unit)}</span>
           </div>
           <div className="flex justify-between items-center">
             <span className="text-gray-600">Price:</span>

--- a/client/components/DetailPanel/CompareView.tsx
+++ b/client/components/DetailPanel/CompareView.tsx
@@ -3,6 +3,8 @@ import { GearItemWithCalculated } from '../../utils/types';
 import { COLORS, STATUS_TONES } from '../../utils/designSystem';
 import CategoryBadge from '../ui/CategoryBadge';
 import { formatPrice } from '../../utils/formatters';
+import { formatWeight } from '../../utils/weightUnit';
+import { useWeightUnit } from '../../contexts/WeightUnitContext';
 import TruncatedText from '../TruncatedText';
 
 interface CompareViewProps {
@@ -15,6 +17,7 @@ interface CompareViewProps {
 const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDelete }) => {
   const successTone = STATUS_TONES.success;
   const errorTone = STATUS_TONES.error;
+  const { unit } = useWeightUnit();
 
   const [selectedItems, setSelectedItems] = useState<string[]>([]);
 
@@ -113,7 +116,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                           className="font-semibold text-gray-900"
                           style={isMin ? { color: successTone.text } : isMax ? { color: errorTone.text } : undefined}
                         >
-                          {weight}g
+                          {formatWeight(weight, unit)}
                           {isMin && <span className="ml-0.5 text-3xs">★</span>}
                         </span>
                       </td>
@@ -186,7 +189,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
           {/* Difference summary */}
           {analysis && (
             <div className="flex gap-3 text-xs text-gray-500">
-              <span>Δ Weight: <span className="font-semibold text-gray-700">{analysis.weightDiff}g</span></span>
+              <span>Δ Weight: <span className="font-semibold text-gray-700">{formatWeight(analysis.weightDiff, unit)}</span></span>
               <span>Δ Price: <span className="font-semibold text-gray-700">{formatPrice(analysis.priceDiff)}</span></span>
             </div>
           )}
@@ -267,7 +270,7 @@ const CompareView: React.FC<CompareViewProps> = ({ items, viewMode, onEdit, onDe
                     {/* Weight and price */}
                     <div className="text-right flex flex-col justify-center">
                       <div className="text-xs font-semibold text-gray-900 leading-tight whitespace-nowrap">
-                        {item.totalWeight}g
+                        {formatWeight(item.totalWeight, unit)}
                       </div>
                       <div className="text-xs text-gray-500 mt-1 leading-tight whitespace-nowrap">
                         {formatPrice(item.totalPrice || 0)}

--- a/client/components/DetailPanel/OverviewView.tsx
+++ b/client/components/DetailPanel/OverviewView.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import { GearItemWithCalculated } from '../../utils/types';
 import { formatPrice } from '../../utils/formatters';
+import { formatWeight } from '../../utils/weightUnit';
+import { useWeightUnit } from '../../contexts/WeightUnitContext';
 import ItemListCard from './ItemListCard';
 import { getQuantityForDisplayMode } from '../../utils/chartHelpers';
 import { QuantityDisplayMode } from '../../utils/types';
@@ -13,6 +15,7 @@ interface OverviewViewProps {
 }
 
 const OverviewView: React.FC<OverviewViewProps> = ({ items, viewMode, onItemClick, quantityDisplayMode }) => {
+  const { unit } = useWeightUnit();
   const getItemValue = (item: GearItemWithCalculated) => {
     const quantity = getQuantityForDisplayMode(item, quantityDisplayMode);
     return viewMode === 'cost'
@@ -78,7 +81,7 @@ const OverviewView: React.FC<OverviewViewProps> = ({ items, viewMode, onItemClic
         <div className="space-y-2 text-xs">
           <div className="flex justify-between items-center">
             <span className="text-gray-600">Weight:</span>
-            <span className="font-semibold text-gray-900">{stats.totalWeight}g</span>
+            <span className="font-semibold text-gray-900">{formatWeight(stats.totalWeight, unit)}</span>
           </div>
           <div className="flex justify-between items-center">
             <span className="text-gray-600">Price:</span>

--- a/client/components/DetailPanel/TableView.tsx
+++ b/client/components/DetailPanel/TableView.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { GearItemWithCalculated } from '../../utils/types';
 import { COLORS } from '../../utils/designSystem';
 import { formatPrice } from '../../utils/formatters';
+import { formatWeight } from '../../utils/weightUnit';
+import { useWeightUnit } from '../../contexts/WeightUnitContext';
 import TruncatedText from '../TruncatedText';
 
 interface TableViewProps {
@@ -13,6 +15,7 @@ interface TableViewProps {
 }
 
 const TableView: React.FC<TableViewProps> = ({ items, viewMode, onEdit, onDelete, onItemClick }) => {
+  const { unit } = useWeightUnit();
   // アイテムを重さ昇順でソート
   const sortedItems = useMemo(() => {
     return [...items].sort((a, b) => (a.totalWeight || 0) - (b.totalWeight || 0));
@@ -68,7 +71,7 @@ const TableView: React.FC<TableViewProps> = ({ items, viewMode, onEdit, onDelete
         <div className="space-y-1.5 text-xs">
           <div className="flex justify-between items-center">
             <span className="text-gray-500">Weight</span>
-            <span className="font-semibold text-gray-900">{stats.totalWeight}g</span>
+            <span className="font-semibold text-gray-900">{formatWeight(stats.totalWeight, unit)}</span>
           </div>
           <div className="flex justify-between items-center">
             <span className="text-gray-500">Price</span>
@@ -139,7 +142,7 @@ const TableView: React.FC<TableViewProps> = ({ items, viewMode, onEdit, onDelete
                     {/* Weight and meta */}
                     <div className="text-right flex flex-col justify-center">
                       <div className="text-xs font-semibold text-gray-900 leading-tight whitespace-nowrap">
-                        {item.totalWeight}g
+                        {formatWeight(item.totalWeight, unit)}
                       </div>
                       <div className="text-xs text-gray-500 mt-1 leading-tight whitespace-nowrap">
                         <span className="font-medium">{weightPercentage}%</span>

--- a/client/components/EditGearModal.tsx
+++ b/client/components/EditGearModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { GearItemWithCalculated, Category } from '../utils/types'
 import SeasonBar from './SeasonBar'
 import { getPriorityColor } from '../utils/designSystem'
+import { useWeightInput } from '../hooks/useWeightInput'
 
 interface EditGearModalProps {
   isOpen: boolean
@@ -31,11 +32,12 @@ const EditGearModal: React.FC<EditGearModalProps> = ({
     imageUrl: gear.imageUrl || '',
     requiredQuantity: gear.requiredQuantity,
     ownedQuantity: gear.ownedQuantity,
-    weightGrams: gear.weightGrams || '',
     priceCents: gear.priceCents || '',
     seasons: gear.seasons || [],
     priority: gear.priority
   })
+
+  const { inputValue: weightInput, setInputValue: setWeightInput, toGrams, unit } = useWeightInput(gear.weightGrams)
 
   useEffect(() => {
     if (isOpen) {
@@ -47,7 +49,6 @@ const EditGearModal: React.FC<EditGearModalProps> = ({
         imageUrl: gear.imageUrl || '',
         requiredQuantity: gear.requiredQuantity,
         ownedQuantity: gear.ownedQuantity,
-        weightGrams: gear.weightGrams || '',
         priceCents: gear.priceCents || '',
         seasons: gear.seasons || [],
         priority: gear.priority
@@ -66,7 +67,7 @@ const EditGearModal: React.FC<EditGearModalProps> = ({
       imageUrl: formData.imageUrl || undefined,
       requiredQuantity: formData.requiredQuantity,
       ownedQuantity: formData.ownedQuantity,
-      weightGrams: formData.weightGrams ? parseInt(String(formData.weightGrams)) : undefined,
+      weightGrams: toGrams(),
       priceCents: formData.priceCents ? parseInt(String(formData.priceCents)) : undefined,
       seasons: formData.seasons,
       priority: formData.priority
@@ -215,15 +216,16 @@ const EditGearModal: React.FC<EditGearModalProps> = ({
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className={labelClassName}>
-                Weight (grams)
+                Weight ({unit})
               </label>
               <input
                 type="number"
                 min="0"
-                value={formData.weightGrams}
-                onChange={(e) => setFormData({ ...formData, weightGrams: e.target.value })}
+                step={unit === 'oz' ? 0.1 : 1}
+                value={weightInput}
+                onChange={(e) => setWeightInput(e.target.value)}
                 className={fieldClassName}
-                placeholder="0"
+                placeholder={unit === 'oz' ? '0.0' : '0'}
               />
             </div>
             <div>

--- a/client/components/GearForm.tsx
+++ b/client/components/GearForm.tsx
@@ -3,6 +3,8 @@ import { GearItemWithCalculated, GearItemForm, LLMExtractionResult, Category, We
 import { extractFromUrl } from '../services/llmService'
 import { sanitizeGearForm } from '../utils/helpers'
 import { useImageUpload } from '../hooks/useImageUpload'
+import { useWeightInput } from '../hooks/useWeightInput'
+import { convertFromGrams } from '../utils/weightUnit'
 import { STATUS_TONES } from '../utils/designSystem'
 import Button from './ui/Button'
 
@@ -20,6 +22,9 @@ const GearForm: React.FC<GearFormProps> = ({ gear, editingGear, categories = [],
   const inputClassName = 'input w-full px-3 py-2 rounded-md focus:outline-none'
   const successTone = STATUS_TONES.success
   const errorTone = STATUS_TONES.error
+
+  const initialWeight = editingGear?.weightGrams ?? gear?.weightGrams ?? null
+  const { inputValue: weightInput, setInputValue: setWeightInput, toGrams, unit } = useWeightInput(initialWeight)
 
   const [form, setForm] = useState<GearItemForm>({
     name: '',
@@ -126,6 +131,11 @@ const GearForm: React.FC<GearFormProps> = ({ gear, editingGear, categories = [],
         categoryId: categories.find(cat => cat.name === extractedData.suggestedCategory)?.id || prev.categoryId
       }))
 
+      // 重量入力欄を抽出値で更新（単位付き表示）
+      if (extractedData.weightGrams) {
+        setWeightInput(String(convertFromGrams(extractedData.weightGrams, unit)))
+      }
+
       // 画像プレビューも更新
       if (extractedData.imageUrl) {
         setPreview(extractedData.imageUrl)
@@ -147,16 +157,16 @@ const GearForm: React.FC<GearFormProps> = ({ gear, editingGear, categories = [],
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    
-    // フォームデータをサニタイズ
-    const sanitizedForm = sanitizeGearForm(form)
-    
+
+    // 重量は単位対応入力から確定値（グラム）を取得
+    const sanitizedForm = sanitizeGearForm({ ...form, weightGrams: toGrams() })
+
     // 必須フィールドのバリデーション
     if (!sanitizedForm.name.trim()) {
       alert('Product name is required')
       return
     }
-    
+
     onSave(sanitizedForm)
   }
 
@@ -353,13 +363,14 @@ const GearForm: React.FC<GearFormProps> = ({ gear, editingGear, categories = [],
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className={labelClassName}>
-                Weight (grams)
+                Weight ({unit})
               </label>
               <input
                 type="number"
                 min="0"
-                value={form.weightGrams || ''}
-                onChange={(e) => handleChange('weightGrams', e.target.value ? parseInt(e.target.value) : undefined)}
+                step={unit === 'oz' ? 0.1 : 1}
+                value={weightInput}
+                onChange={(e) => setWeightInput(e.target.value)}
                 className={inputClassName}
               />
             </div>

--- a/client/components/charts/ChartSummaryFooter.tsx
+++ b/client/components/charts/ChartSummaryFooter.tsx
@@ -8,7 +8,7 @@ import YenIcon from '../icons/YenIcon'
 import BackpackIcon from '../icons/BackpackIcon'
 import { useWeightUnit } from '../../contexts/WeightUnitContext'
 import { useCurrency } from '../../contexts/CurrencyContext'
-import { formatWeight } from '../../utils/weightUnit'
+import { formatWeight, formatWeightLarge } from '../../utils/weightUnit'
 import { formatPriceWithCurrency } from '../../utils/formatters'
 
 const VIEW_MODE_OPTIONS = [
@@ -153,8 +153,8 @@ const ChartSummaryFooter: React.FC<ChartSummaryFooterProps> = ({
           <div className="flex justify-center">
             <SummaryStatCard
               label="Weight"
-              value={`${(totalWeight / 1000).toFixed(3)} kg`}
-              subValue={`${totalWeight}g`}
+              value={formatWeightLarge(totalWeight, unit)}
+              subValue={formatWeight(totalWeight, unit)}
               isActive
               wide
               icon={<ScaleIcon className="w-3.5 h-3.5 flex-shrink-0 text-gray-600 dark:text-gray-300" />}

--- a/client/components/gear-input/GearInputModal.tsx
+++ b/client/components/gear-input/GearInputModal.tsx
@@ -4,6 +4,7 @@ import { ExtractedGearWithUrl } from '../../utils/gearExtractionHelpers'
 import { extractFromUrl } from '../../services/llmService'
 import { sanitizeGearForm } from '../../utils/helpers'
 import { useImageUpload } from '../../hooks/useImageUpload'
+import { useWeightInput } from '../../hooks/useWeightInput'
 import { STATUS_TONES } from '../../utils/designSystem'
 import Button from '../ui/Button'
 
@@ -57,6 +58,9 @@ const GearInputModal: React.FC<GearInputModalProps> = ({
 
   const [isExtracting, setIsExtracting] = useState(false)
   const [extractionResult, setExtractionResult] = useState<LLMExtractionResult | null>(null)
+
+  // 重量入力は単位対応（g/oz）。form.weightGrams は初期値/外部更新のトリガーとして使用
+  const { inputValue: weightInput, setInputValue: setWeightInput, toGrams, unit } = useWeightInput(form.weightGrams ?? null)
 
   // バルクモード用の状態
   const [currentBulkIndex, setCurrentBulkIndex] = useState(0)
@@ -211,8 +215,8 @@ const GearInputModal: React.FC<GearInputModalProps> = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    // フォームデータをサニタイズ
-    const sanitizedForm = sanitizeGearForm(form)
+    // 重量は単位対応入力から確定値（グラム）を取得
+    const sanitizedForm = sanitizeGearForm({ ...form, weightGrams: toGrams() })
 
     // 必須フィールドのバリデーション
     if (!sanitizedForm.name.trim()) {
@@ -518,13 +522,14 @@ const GearInputModal: React.FC<GearInputModalProps> = ({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
               <label className={labelClassName}>
-                Weight (grams) {bulkMode && emptyFields.includes('weightGrams') && <span style={{ color: errorTone.text }}>!</span>}
+                Weight ({unit}) {bulkMode && emptyFields.includes('weightGrams') && <span style={{ color: errorTone.text }}>!</span>}
               </label>
               <input
                 type="number"
                 min="0"
-                value={form.weightGrams || ''}
-                onChange={(e) => handleChange('weightGrams', e.target.value ? parseInt(e.target.value) : undefined)}
+                step={unit === 'oz' ? 0.1 : 1}
+                value={weightInput}
+                onChange={(e) => setWeightInput(e.target.value)}
                 className={getFieldClassName('weightGrams')}
                 style={getFieldStyle('weightGrams')}
               />

--- a/client/hooks/useWeightInput.ts
+++ b/client/hooks/useWeightInput.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { convertFromGrams, convertToGrams } from '../utils/weightUnit'
+import { useWeightUnit } from '../contexts/WeightUnitContext'
+
+/**
+ * フォーム入力用の重量フィールドを単位対応にするフック。
+ * - 内部はグラム保存（DB と整合）
+ * - 表示は現在単位（g/oz）
+ * - 単位切替時は入力中の値を再換算してユーザー入力を保持
+ *
+ * 使い方:
+ *   const { inputValue, setInputValue, toGrams, unit } = useWeightInput(initialGrams)
+ *   <input value={inputValue} onChange={e => setInputValue(e.target.value)} />
+ *   // 保存時: toGrams()
+ */
+export function useWeightInput(initialGrams: number | null | undefined) {
+  const { unit } = useWeightUnit()
+  const [inputValue, setInputValue] = useState<string>(() =>
+    initialGrams != null ? String(convertFromGrams(initialGrams, unit)) : ''
+  )
+  const prevUnitRef = useRef(unit)
+  const initialGramsRef = useRef(initialGrams)
+
+  // initialGrams が変わったら（例: 編集対象の切替）再初期化
+  useEffect(() => {
+    if (initialGrams !== initialGramsRef.current) {
+      initialGramsRef.current = initialGrams
+      setInputValue(initialGrams != null ? String(convertFromGrams(initialGrams, unit)) : '')
+    }
+  }, [initialGrams, unit])
+
+  // 単位切替時: 入力中の値を再換算（ユーザー入力を捨てない）
+  useEffect(() => {
+    if (prevUnitRef.current !== unit) {
+      setInputValue(current => {
+        if (!current) return current
+        const num = parseFloat(current)
+        if (isNaN(num)) return current
+        const grams = convertToGrams(num, prevUnitRef.current)
+        return grams > 0 ? String(convertFromGrams(grams, unit)) : ''
+      })
+      prevUnitRef.current = unit
+    }
+  }, [unit])
+
+  const toGrams = useCallback((): number | undefined => {
+    if (!inputValue) return undefined
+    const num = parseFloat(inputValue)
+    if (isNaN(num)) return undefined
+    return convertToGrams(num, unit)
+  }, [inputValue, unit])
+
+  return { inputValue, setInputValue, toGrams, unit }
+}


### PR DESCRIPTION
## 概要
Issue #41 の PR2。`WeightUnitContext` の g/oz トグルをアプリ全域で有効化する。
これまでトグルは 3 箇所でしか効いておらず「機能が壊れて見える」状態だったため、
表示・入力の全経路を単位対応に統一する。

## 変更内容
### 表示側（`formatWeight` / `formatWeightLarge`）
- `DetailPanel/OverviewView.tsx`
- `DetailPanel/TableView.tsx`（統計・アイテム行の両方）
- `DetailPanel/CategorySummaryView.tsx`
- `DetailPanel/CompareView.tsx`（比較表、Δ Weight、アイテムリスト）
- `charts/ChartSummaryFooter.tsx`（kg ハードコード → `formatWeightLarge` に統一）

### 入力側（新規 `useWeightInput` フック）
- `client/hooks/useWeightInput.ts` を新規追加
  - 内部はグラム保存（DB と整合）、表示は現在単位
  - 単位切替時は入力中の値を再換算してユーザー入力を保持
- `EditGearModal.tsx`
- `GearForm.tsx`（URL 抽出時も単位に合わせて入力欄を更新）
- `gear-input/GearInputModal.tsx`（バルクモードのアイテム切替時も再初期化）
- `BulkActionModal.tsx`（プレースホルダとラベルを動的化）

## 方針
- DB はグラム保存のまま
- 表示・入力層でのみ g/oz 変換
- `.claude/rules/ui-components.md` の「重量表示ルール」に整合

## テスト計画
- [ ] `npm run typecheck` パス（確認済み）
- [ ] `npm run build` パス（確認済み）
- [ ] フッターの g/oz トグルを切替 → テーブル、カード、詳細パネル、比較ビュー、チャートすべての重量表示が同時に切り替わること
- [ ] EditGearModal / GearForm / GearInputModal / BulkActionModal でラベルが現在単位を表示し、入力→保存で正しくグラムに変換されること
- [ ] 入力中に単位をトグルしても、入力中の値がロストせず換算されること

refs #41

https://claude.ai/code/session_01Xnaq8vpBRrDvwHWVydfFs7
