### PR TITLE
feat(ui): 空状態UIを追加し初回ユーザー体験を改善 (PR3)

### DIFF
--- a/client/components/ChartPanel.tsx
+++ b/client/components/ChartPanel.tsx
@@ -457,6 +457,8 @@ const ChartPanel: React.FC<ChartPanelProps> = React.memo(({
                 activePackItemIds={activePackItemIds}
                 onTogglePackItem={onTogglePackItem}
                 onAddItemsToPack={onAddItemsToPack}
+                onShowForm={onShowForm}
+                onShowUrlImport={onShowUrlImport}
               />
           </div>
         </Card>

--- a/client/components/GearDetailPanel.tsx
+++ b/client/components/GearDetailPanel.tsx
@@ -5,6 +5,7 @@ import ComparisonTable from './ComparisonTable';
 import TableHeader from './GearTable/TableHeader';
 import TableRow from './GearTable/TableRow';
 import BulkActionBar from './BulkActionBar';
+import EmptyState from './ui/EmptyState';
 import { SPACING_SCALE } from '../utils/designSystem';
 import { filterByCategories, sortItems } from '../utils/sortHelpers';
 import { useItemSelection } from '../hooks/useItemSelection';
@@ -36,6 +37,10 @@ interface GearDetailPanelProps {
   activePackItemIds?: string[];
   onTogglePackItem?: (itemId: string) => void;
   onAddItemsToPack?: (itemIds: string[]) => void;
+  /** 新規ギア追加フォームを開く（空状態の CTA 用） */
+  onShowForm?: () => void;
+  /** URL インポートを開く（空状態の二次 CTA 用） */
+  onShowUrlImport?: () => void;
 }
 
 const MAX_COMPARE_ITEMS = 4;
@@ -62,6 +67,8 @@ const GearDetailPanel: React.FC<GearDetailPanelProps> = ({
   activePackItemIds = [],
   onTogglePackItem,
   onAddItemsToPack,
+  onShowForm,
+  onShowUrlImport,
 }) => {
   const { sortField, sortDirection, handleSort, forceSort } = useGearSort();
   const { changedFields, handleFieldChange, clearChangedFields } = useChangedFields(onUpdateItem);
@@ -221,23 +228,53 @@ const GearDetailPanel: React.FC<GearDetailPanelProps> = ({
     );
   }
 
+  // 全体で 0 件 / フィルタ後に 0 件を判別
+  const hasAnyItem = items.length > 0;
+  const hasFilteredItem = chartFilteredItems.length > 0;
+  const showGlobalEmpty = !hasAnyItem;
+  const showFilteredEmpty = hasAnyItem && !hasFilteredItem;
+
+  // 全体 0 件: 初回ユーザー向けの CTA を含む空状態
+  if (showGlobalEmpty) {
+    return (
+      <div className="w-full h-full min-w-0 flex items-center justify-center">
+        <EmptyState
+          title="まだギアがありません"
+          description="最初のアイテムを登録して、パックの重量管理を始めましょう。"
+          actionLabel={onShowForm ? '+ ギアを追加' : undefined}
+          onAction={onShowForm}
+          secondaryActionLabel={onShowUrlImport ? 'URL から取り込む' : undefined}
+          onSecondaryAction={onShowUrlImport}
+        />
+      </div>
+    );
+  }
+
   // Cardモード
   if (gearViewMode === 'card') {
     return (
       <div className="w-full h-full min-w-0 overflow-hidden">
-        <CardGridView
-          items={chartFilteredItems}
-          viewMode={viewMode === 'cost' ? 'cost' : 'weight'}
-          quantityDisplayMode={quantityDisplayMode}
-          selectedItemId={selectedItemId}
-          hoveredItemId={hoveredItemId}
-          onItemSelect={onItemSelect}
-          onItemHover={onItemHover}
-          activePackName={activePack?.name}
-          activePackItemIds={activePackItemIds}
-          onTogglePackItem={onTogglePackItem}
-          onEdit={onEdit}
-        />
+        {showFilteredEmpty ? (
+          <EmptyState
+            compact
+            title="該当するギアがありません"
+            description="カテゴリや表示モードのフィルタを変更すると結果が表示されます。"
+          />
+        ) : (
+          <CardGridView
+            items={chartFilteredItems}
+            viewMode={viewMode === 'cost' ? 'cost' : 'weight'}
+            quantityDisplayMode={quantityDisplayMode}
+            selectedItemId={selectedItemId}
+            hoveredItemId={hoveredItemId}
+            onItemSelect={onItemSelect}
+            onItemHover={onItemHover}
+            activePackName={activePack?.name}
+            activePackItemIds={activePackItemIds}
+            onTogglePackItem={onTogglePackItem}
+            onEdit={onEdit}
+          />
+        )}
       </div>
     );
   }
@@ -273,7 +310,18 @@ const GearDetailPanel: React.FC<GearDetailPanelProps> = ({
               onSelectAll={handleSelectAll}
             />
             <tbody>
-              {processedItems.map((item) => (
+              {showFilteredEmpty && (
+                <tr>
+                  <td colSpan={99}>
+                    <EmptyState
+                      compact
+                      title="該当するギアがありません"
+                      description="カテゴリや表示モードのフィルタを変更すると結果が表示されます。"
+                    />
+                  </td>
+                </tr>
+              )}
+              {!showFilteredEmpty && processedItems.map((item) => (
                 <TableRow
                   key={item.id}
                   id={`gear-item-${item.id}`}

--- a/client/components/PackDetailPage.tsx
+++ b/client/components/PackDetailPage.tsx
@@ -7,6 +7,7 @@ import { getQuantityForDisplayMode } from '../utils/chartHelpers';
 import { formatWeight, formatWeightLarge } from '../utils/weightUnit';
 import { useWeightUnit } from '../contexts/WeightUnitContext';
 import CategoryBadge from './ui/CategoryBadge';
+import EmptyState from './ui/EmptyState';
 
 const fallbackUserId = 'local-user';
 
@@ -78,7 +79,11 @@ export default function PackDetailPage() {
         </div>
         {isLoading && <p className="px-4 py-4 text-sm text-gray-500">Loading gear...</p>}
         {!isLoading && items.length === 0 && (
-          <p className="px-4 py-4 text-sm text-gray-500">No items in this pack.</p>
+          <EmptyState
+            compact
+            title="このパックにはまだアイテムがありません"
+            description="ホーム画面のギア一覧から、このパックに追加するアイテムを選びましょう。"
+          />
         )}
         {!isLoading &&
           items.map((item) => (

--- a/client/components/ui/EmptyState.tsx
+++ b/client/components/ui/EmptyState.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { COLORS, SPACING_SCALE } from '../../utils/designSystem';
+import Button from './Button';
+
+interface EmptyStateProps {
+  /** メインメッセージ（例: "まだギアがありません"） */
+  title: string;
+  /** 補足説明（任意） */
+  description?: string;
+  /** アイコン（任意。SVG 要素を渡す） */
+  icon?: React.ReactNode;
+  /** CTA ボタンのラベル（任意） */
+  actionLabel?: string;
+  /** CTA クリック時の動作 */
+  onAction?: () => void;
+  /** 二次的な CTA（任意） */
+  secondaryActionLabel?: string;
+  onSecondaryAction?: () => void;
+  /** コンパクト表示（詳細パネル内などの小領域用） */
+  compact?: boolean;
+  className?: string;
+}
+
+/**
+ * アイテム 0 件時の空状態 UI。
+ * 初回ユーザーが「壊れている」と感じないよう、次のアクションに誘導する。
+ */
+const EmptyState: React.FC<EmptyStateProps> = ({
+  title,
+  description,
+  icon,
+  actionLabel,
+  onAction,
+  secondaryActionLabel,
+  onSecondaryAction,
+  compact = false,
+  className = '',
+}) => {
+  const padding = compact ? SPACING_SCALE.lg : SPACING_SCALE['2xl'];
+  const titleSize = compact ? 14 : 16;
+  const descSize = compact ? 12 : 13;
+
+  return (
+    <div
+      role="status"
+      className={`flex flex-col items-center justify-center text-center ${className}`}
+      style={{ padding, gap: SPACING_SCALE.md }}
+    >
+      {icon && (
+        <div style={{ color: COLORS.text.muted, marginBottom: SPACING_SCALE.xs }}>
+          {icon}
+        </div>
+      )}
+      <div style={{ fontSize: titleSize, fontWeight: 600, color: COLORS.text.primary }}>
+        {title}
+      </div>
+      {description && (
+        <p
+          style={{
+            fontSize: descSize,
+            color: COLORS.text.muted,
+            maxWidth: 360,
+            lineHeight: 1.5,
+          }}
+        >
+          {description}
+        </p>
+      )}
+      {(actionLabel || secondaryActionLabel) && (
+        <div className="flex flex-wrap items-center justify-center gap-2" style={{ marginTop: SPACING_SCALE.sm }}>
+          {actionLabel && onAction && (
+            <Button type="button" variant="primary" onClick={onAction}>
+              {actionLabel}
+            </Button>
+          )}
+          {secondaryActionLabel && onSecondaryAction && (
+            <Button type="button" variant="secondary" onClick={onSecondaryAction}>
+              {secondaryActionLabel}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EmptyState;


### PR DESCRIPTION
## 概要
Issue #41 の PR3。アイテム 0 件時に真っ白な画面が表示され、初回ユーザーが「壊れている」と感じて離脱する UX バグを解消する。

## 変更内容
### 新規コンポーネント
- `client/components/ui/EmptyState.tsx`
  - タイトル / 説明 / 一次 CTA / 二次 CTA / compact モードを持つ汎用 UI
  - `designSystem.ts` の `COLORS` / `SPACING_SCALE` に準拠
  - `role="status"` でアクセシビリティ配慮

### 適用箇所
- **`GearDetailPanel.tsx`**
  - 全体で 0 件（初回ユーザー）→「まだギアがありません」+ `+ ギアを追加` / `URL から取り込む` CTA
  - フィルタ後 0 件（アイテムはあるがフィルタ該当なし）→ コンパクト表示で案内のみ
  - Table / Card 両モードに対応
- **`PackDetailPage.tsx`**
  - パックに 0 件 → コンパクトな空状態表示
- **`ChartPanel.tsx`**
  - `onShowForm` / `onShowUrlImport` を GearDetailPanel に伝搬し、空状態 CTA から直接フォームを開けるようにする

## 方針
- 既存の「No items」テキストを段階的に EmptyState に置換
- 詳細パネル内の小さな子ビュー（OverviewView 等の "No items" テキスト）は今回は据え置き

## テスト計画
- [ ] `npm run typecheck` パス（確認済み）
- [ ] `npm run build` パス（確認済み）
- [ ] 新規ユーザーでログイン → 空状態 UI と CTA が表示されること
- [ ] `+ ギアを追加` クリックで GearForm が開くこと
- [ ] アイテム登録後、通常の一覧表示に遷移すること
- [ ] フィルタ（カテゴリ選択等）で該当 0 件になった場合、コンパクト表示に切り替わること
- [ ] パック未選択状態で PackDetailPage を開き、空状態 UI が表示されること

refs #41

https://claude.ai/code/session_01Xnaq8vpBRrDvwHWVydfFs7
