### PR TITLE
refactor(ui): 残存するハードコード値を designSystem に置換 (PR4)

### DIFF
--- a/client/components/DetailPanel/CardGridView.tsx
+++ b/client/components/DetailPanel/CardGridView.tsx
@@ -57,7 +57,7 @@ const ExpandedPanel: React.FC<{
     style={{
       gridColumn: '1 / -1',
       gridRow: 'span 2',
-      borderTop: `1px solid ${COLORS.gray[200]}`,
+      borderTop: BORDERS.divider,
       backgroundColor: COLORS.gray[50],
     }}
   >

--- a/client/components/ui/ULStatusBadge.tsx
+++ b/client/components/ui/ULStatusBadge.tsx
@@ -12,7 +12,7 @@ interface ULStatusBadgeProps {
 
 // De Stijl: UL = Blue (達成), LW = Yellow (警告), Trad = 黒枠グレー
 const UL_STATUS_CONFIG = {
-  ultralight:  { label: '⚡ UL',  color: '#FFFFFF',           bgColor: mondrian.blue },
+  ultralight:  { label: '⚡ UL',  color: COLORS.white,        bgColor: mondrian.blue },
   lightweight: { label: 'LW',     color: mondrian.black,      bgColor: alpha(mondrian.yellow, 0.4) },
   traditional: { label: 'Trad',   color: COLORS.text.primary, bgColor: COLORS.gray[200] }
 } as const


### PR DESCRIPTION
## 概要
Issue #41 の PR4。

## 重要な発見：スコープは当初想定より大幅に小さい

当初の監査では「125 箇所のインラインスタイル」とされていたが、改めて分類した結果、そのほとんどは既に designSystem トークンを使用済みか、正当な動的値であると判明した。

分類結果（125 件中）:
- **A. 既に designSystem 使用済み**: ~35 件（`COLORS.xxx`, `STATUS_TONES.xxx`, `BORDERS.xxx` 等）
- **B. 動的・計算値**: ~60 件（grid 座標、hover 状態の box-shadow、データ由来の色、位置計算など。仕様上インラインが正解）
- **C. 真のハードコード候補**: ~30 件 → さらに精査すると、designSystem に等価トークンが存在するものはごく少数

## 変更内容

- `CardGridView.tsx`: `1px solid ${COLORS.gray[200]}` → `BORDERS.divider`
- `ULStatusBadge.tsx`: `'#FFFFFF'` → `COLORS.white`

## 据え置いたもの（理由付き）

| 箇所 | 理由 |
|------|------|
| `CardGridView.tsx` dashed border (line 82) | designSystem に dashed variant なし |
| `CardGridView.tsx` hover box-shadow (line 175) | border を使うと layout shift する。box-shadow での focus-ring は意図的 |
| `ChatPopup.tsx` 左向き shadow | 方向性があり、SHADOW トークン（下方向）と非等価 |
| `GearForm/GearInputModal` 24px アイコンボタン | SPACING_SCALE に相当値なし。新規トークン追加はスコープ外 |
| `UrlBulkImportModal.tsx` lineHeight 1.6 | Tailwind/designSystem どちらにも 1.6 ちょうどはない |

## 今後の提言

- B の「動的値」は今後も inline で問題ない
- 新規トークン追加が必要な場合は別途議論（例: `CONTROL_SIZES` for 24px アイコン）
- ESLint ルールで「新規の ハードコード hex/px は警告」を導入すれば、退化を防げる

## テスト計画
- [ ] `npm run typecheck` パス（確認済み）
- [ ] `npm run build` パス（確認済み）
- [ ] CardGridView の展開パネル上部仕切り線が以前と同じ見た目であること
- [ ] ULStatusBadge の Ultralight バッジの前景色が白のままであること

refs #41

https://claude.ai/code/session_01Xnaq8vpBRrDvwHWVydfFs7
