### PR TITLE
security(server): imageProxy の SSRF 脆弱性を修正

### DIFF
--- a/server/routes/imageProxy.ts
+++ b/server/routes/imageProxy.ts
@@ -1,45 +1,59 @@
 import { Router, Request, Response } from 'express';
 import axios from 'axios';
+import { assertSafeExternalUrl } from '../utils/ssrfGuard.js';
 
 const router = Router();
 
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10MB
+const FETCH_TIMEOUT_MS = 10000;
+
 /**
  * 画像プロキシエンドポイント
- * 外部画像URLをプロキシしてCORS問題を回避
+ * 外部画像URLをプロキシしてCORS問題を回避。
+ * SSRF 対策として http(s) プロトコル限定、プライベート IP 拒否、
+ * リダイレクト禁止、content-type 検証、サイズ上限を適用する。
  */
 router.get('/proxy', async (req: Request, res: Response) => {
+  const rawUrl = req.query.url;
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
+    return res.status(400).json({ success: false, message: 'Image URL is required' });
+  }
+  if (rawUrl.length > 2048) {
+    return res.status(400).json({ success: false, message: 'URL is too long' });
+  }
+
+  let safeUrl: URL;
   try {
-    const imageUrl = req.query.url as string;
+    safeUrl = await assertSafeExternalUrl(rawUrl);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'URL validation failed';
+    return res.status(400).json({ success: false, message });
+  }
 
-    if (!imageUrl) {
-      return res.status(400).json({
-        success: false,
-        message: 'Image URL is required'
-      });
-    }
-
-    // 外部画像を取得
-    const response = await axios.get(imageUrl, {
+  try {
+    const response = await axios.get(safeUrl.toString(), {
       responseType: 'arraybuffer',
       headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+        'Accept': 'image/*',
       },
-      timeout: 10000
+      timeout: FETCH_TIMEOUT_MS,
+      maxRedirects: 0,
+      maxContentLength: MAX_IMAGE_BYTES,
+      validateStatus: status => status >= 200 && status < 300,
     });
 
-    // Content-Typeを設定
-    const contentType = response.headers['content-type'] || 'image/jpeg';
-    res.set('Content-Type', contentType);
-    res.set('Cache-Control', 'public, max-age=86400'); // 24時間キャッシュ
+    const contentType = String(response.headers['content-type'] || '');
+    if (!contentType.startsWith('image/')) {
+      return res.status(415).json({ success: false, message: 'Resource is not an image' });
+    }
 
-    // 画像データを返す
+    res.set('Content-Type', contentType);
+    res.set('Cache-Control', 'public, max-age=86400');
     res.send(response.data);
   } catch (error) {
     console.error('Image proxy error:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to fetch image'
-    });
+    res.status(502).json({ success: false, message: 'Failed to fetch image' });
   }
 });
 

--- a/server/utils/ssrfGuard.ts
+++ b/server/utils/ssrfGuard.ts
@@ -1,0 +1,94 @@
+import dns from 'dns/promises';
+import net from 'net';
+
+/**
+ * SSRF 対策: プライベート / 予約 IP 範囲を検出する。
+ * 以下の範囲を拒否対象とする:
+ *   IPv4: 0/8, 10/8, 127/8, 169.254/16 (link-local/AWS メタデータ),
+ *         172.16/12, 192.168/16, 100.64/10 (CGNAT), 224/4 (multicast)
+ *   IPv6: ::, ::1 (loopback), fc00::/7 (ULA), fe80::/10 (link-local),
+ *         ::ffff:0:0/96 (IPv4 mapped) は内部 IPv4 として再判定
+ */
+const PRIVATE_IPV4_PATTERNS: Array<[number, number, number, number, number]> = [
+  // [A, B, C, D, prefix]
+  [0, 0, 0, 0, 8],
+  [10, 0, 0, 0, 8],
+  [100, 64, 0, 0, 10],
+  [127, 0, 0, 0, 8],
+  [169, 254, 0, 0, 16],
+  [172, 16, 0, 0, 12],
+  [192, 168, 0, 0, 16],
+  [224, 0, 0, 0, 4],
+];
+
+function ipv4InCidr(ip: string, cidr: [number, number, number, number, number]): boolean {
+  const [a, b, c, d] = ip.split('.').map(Number);
+  if ([a, b, c, d].some(n => Number.isNaN(n) || n < 0 || n > 255)) return false;
+  const [ca, cb, cc, cd, prefix] = cidr;
+  const ipInt = (a << 24) | (b << 16) | (c << 8) | d;
+  const cidrInt = (ca << 24) | (cb << 16) | (cc << 8) | cd;
+  const mask = prefix === 0 ? 0 : (-1 << (32 - prefix)) >>> 0;
+  return (ipInt & mask) === (cidrInt & mask);
+}
+
+export function isPrivateIp(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) {
+    return PRIVATE_IPV4_PATTERNS.some(cidr => ipv4InCidr(ip, cidr));
+  }
+  if (family === 6) {
+    const lower = ip.toLowerCase();
+    if (lower === '::' || lower === '::1') return true;
+    if (lower.startsWith('fe80:') || lower.startsWith('fe8') || lower.startsWith('fe9') ||
+        lower.startsWith('fea') || lower.startsWith('feb')) return true; // fe80::/10
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // fc00::/7
+    // IPv4-mapped IPv6: ::ffff:a.b.c.d
+    const mappedMatch = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mappedMatch) return PRIVATE_IPV4_PATTERNS.some(c => ipv4InCidr(mappedMatch[1], c));
+    return false;
+  }
+  return true; // IP でない文字列は安全側に倒して拒否
+}
+
+/**
+ * 外部 URL が SSRF 的に安全か検証する。
+ * - プロトコルは http/https のみ
+ * - 解決された全 IP がパブリックであること
+ *
+ * DNS 再バインディング攻撃には完全対応していない（事前解決 IP と
+ * 実際の接続時 IP が異なる可能性あり）。必要なら custom http.Agent
+ * の lookup フックで接続時検証を追加する。
+ */
+export async function assertSafeExternalUrl(rawUrl: string): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Only http(s) URLs are allowed');
+  }
+  const hostname = url.hostname;
+  if (!hostname) throw new Error('URL missing hostname');
+
+  // ホスト名が IP リテラルの場合はその場で判定
+  if (net.isIP(hostname)) {
+    if (isPrivateIp(hostname)) throw new Error('Private or reserved IP is not allowed');
+    return url;
+  }
+
+  // localhost 等の特別な名前を早期拒否
+  if (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === 'metadata.google.internal') {
+    throw new Error('Private hostname is not allowed');
+  }
+
+  const records = await dns.lookup(hostname, { all: true });
+  if (records.length === 0) throw new Error('Hostname did not resolve');
+  for (const r of records) {
+    if (isPrivateIp(r.address)) {
+      throw new Error('Hostname resolves to a private or reserved IP');
+    }
+  }
+  return url;
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/image/proxy?url=...` が任意 URL を fetch できる SSRF 脆弱性を多層防御で塞ぐ。

### 追加した防御
1. **プロトコル制限**: `http:` / `https:` のみ許可
2. **DNS 事前解決 + プライベート IP 拒否**: ホスト名を resolve して、プライベート / 予約範囲 (10/8, 127/8, 169.254/16 (AWS メタデータ), 172.16/12, 192.168/16, 100.64/10 (CGNAT), ::1, fc00::/7, fe80::/10 等) に該当する IP を全拒否。IPv4-mapped IPv6 も再判定。
3. **特別名拒否**: `localhost` / `*.localhost` / `metadata.google.internal`
4. **リダイレクト禁止**: `maxRedirects: 0` でリダイレクト迂回を防止
5. **Content-Type 検証**: `image/*` 以外は 415 で拒否
6. **サイズ上限**: 10MB / URL 長は 2048 文字まで

### 既知の限界
DNS 再バインディング攻撃には完全対応していない（事前解決 IP と実際の接続時 IP が異なりうる）。必要なら custom `http.Agent` の `lookup` フックで接続時検証を追加する。コード内コメントに明記。

Closes #51

## Test plan

- [x] `npm run server:build` 成功
- [x] `npm run lint` 成功
- [ ] 正常系: `curl "http://localhost:8000/api/v1/image/proxy?url=https://example.com/image.jpg"` が画像バイナリを返す
- [ ] 異常系: `curl "http://localhost:8000/api/v1/image/proxy?url=http://169.254.169.254/"` が 400 (Private or reserved IP)
- [ ] 異常系: `curl "http://localhost:8000/api/v1/image/proxy?url=http://localhost/"` が 400
- [ ] 異常系: `file://` や `gopher://` は 400 (Only http(s))
- [ ] 異常系: 画像以外の URL は 415

🤖 Generated with [Claude Code](https://claude.com/claude-code)