### PR TITLE
security(server): エラーハンドラーの情報漏洩を修正

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -7,6 +7,7 @@ import { config } from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
+import { randomUUID } from 'crypto';
 
 // Import routes
 import gearRoutes from './routes/gear.js';
@@ -132,12 +133,22 @@ if (distPath) {
 }
 
 // Error handling middleware
-app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
-  console.error('Error:', err);
+app.use((err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  const requestId = randomUUID();
+  const name = err instanceof Error ? err.name : 'UnknownError';
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+
+  // サーバー側にのみ詳細を残す（構造化ロガー導入後は JSON 化）
+  console.error(
+    `[${requestId}] ${req.method} ${req.originalUrl} — ${name}: ${message}`,
+    stack ?? '',
+  );
+
   res.status(500).json({
     success: false,
     message: 'Internal server error',
-    error: process.env.NODE_ENV === 'development' ? err.message : 'Something went wrong'
+    requestId,
   });
 });
 


### PR DESCRIPTION
## Summary

グローバルエラーハンドラーの情報漏洩リスクと型安全性を修正。

### 変更
- `err: any` → `err: unknown` に変更し `instanceof Error` で型ガード
- `NODE_ENV === 'development'` 判定を撤廃 — **本番/開発ともに `err.message` をレスポンスに含めない**
- リクエストごとに `requestId` (UUID) を生成
  - サーバーログ: `[requestId] METHOD URL — name: message` + stack
  - レスポンス: `{ success: false, message: 'Internal server error', requestId }`
- ユーザーは `requestId` を添えて問い合わせ → サーバーログで詳細追跡

Closes #52

## Test plan

- [x] `npm run server:build` 成功
- [x] `npm run lint` 成功
- [ ] わざとエラーを発生させて、レスポンスにスタックが含まれず `requestId` のみ返ることを確認
- [ ] サーバーログ側に同じ `requestId` で詳細が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)