### PR TITLE
feat(llm): OPENAI_MODEL env でモデル ID を上書き可能に

### DIFF
--- a/server/services/openaiClient.ts
+++ b/server/services/openaiClient.ts
@@ -13,7 +13,8 @@ export interface UsageContext {
  */
 export class OpenAIClient {
   private openai: OpenAI | null;
-  private readonly defaultModel = 'gpt-4o';
+  /** OPENAI_MODEL env で上書き可能。未設定時は gpt-4o にフォールバック */
+  private readonly defaultModel = process.env.OPENAI_MODEL ?? 'gpt-4o';
 
   constructor() {
     const apiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary

`OpenAIClient.defaultModel` をハードコードの `'gpt-4o'` から `process.env.OPENAI_MODEL ?? 'gpt-4o'` に変更。env でモデル切替可能に。

## 背景
Project API key には、デフォルトで `gpt-4o` へのアクセス権が無く 403 を返すものがある (`proj_*` キーの多くは `gpt-4o-mini` だけ許可される)。モデル ID を env で上書きできれば、コード変更なしに:

- 権限のある別モデル (`gpt-4o-mini` / `gpt-4-turbo` 等) へ即時切替
- コスト最適化用に `gpt-4o-mini` で運用
- 本番 / STG / dev で異なるモデルを選択

が可能になる。

## 使い方
\`.env\` または Railway の Variables に追記:

\`\`\`
OPENAI_MODEL=gpt-4o-mini
\`\`\`

未設定時は従来通り `gpt-4o` (後方互換維持)。

## Test plan
- [x] `server:build` でタイポ / 型エラー無し (billing.ts の既存エラーは本 PR と無関係)
- [x] `.env` に `OPENAI_MODEL=gpt-4o-mini` を追加して backend 再起動 → 起動ログに `[OpenAI] Client initialized successfully` 表示
- [x] Advisor パネルから日本語で質問 → `gpt-4o-mini` の応答が返り、ギアコンテキスト (HMG バックパック等) も正しく function calling で参照される
- [ ] 本番 (Railway) で `OPENAI_MODEL` を設定 → 同様に切替

🤖 Generated with [Claude Code](https://claude.com/claude-code)