### PR TITLE
feat(ui): ヘッダー再編 + Chat を bottom sheet 化 + Settings 統合

### DIFF
--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -8,6 +8,7 @@ import PacksPage from './PacksPage';
 import PackDetailPage from './PackDetailPage';
 import AppDock from './AppDock';
 import Landing from './Landing';
+import ThemeToggleFab from './ThemeToggleFab';
 
 export default function App() {
   const location = useLocation();
@@ -54,6 +55,9 @@ export default function App() {
 
   return (
     <div className="min-h-screen">
+      {/* viewport 右上 fixed の theme toggle (全ルート共通) */}
+      <ThemeToggleFab />
+
       {/* ルーティング */}
       <Routes>
         <Route

--- a/client/components/ChatSidebar.tsx
+++ b/client/components/ChatSidebar.tsx
@@ -470,27 +470,36 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
   const advisorLastAssistantId = advisor.messages.filter((m) => m.role === 'assistant').at(-1)?.id;
 
   // ==================== Render ====================
+  // Bottom sheet: 画面下部から transform translateY でスライドイン。
+  // backdrop は透過 + blur で、背景の chart / table が見えたまま操作できる。
   return (
     <>
-      {isMobile && isOpen && (
+      {isOpen && (
         <div
-          className="fixed inset-0 z-[39] bg-black/30 transition-opacity duration-300"
+          className="fixed inset-0 z-[39] bg-black/30 backdrop-blur-sm transition-opacity duration-300"
           onClick={onClose}
           aria-hidden="true"
         />
       )}
       <aside
-        className="fixed top-0 right-0 h-full z-40 flex flex-col
+        className="fixed left-0 right-0 bottom-0 z-40 flex flex-col
                    bg-white dark:bg-gray-900
-                   border-l border-gray-200 dark:border-gray-700
+                   border-t border-gray-200 dark:border-gray-700
                    shadow-xl
                    transition-transform duration-300 ease-in-out"
         style={{
-          width: isMobile ? '100%' : '400px',
-          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          height: isMobile ? '85vh' : 'min(70vh, 640px)',
+          transform: isOpen ? 'translateY(0)' : 'translateY(100%)',
+          borderTopLeftRadius: 'var(--radius-surface)',
+          borderTopRightRadius: 'var(--radius-surface)',
         }}
         aria-label="Gear chat assistant"
       >
+        {/* Grabber bar (装飾): 下部シートであることを視覚的に示す */}
+        <div className="flex items-center justify-center pt-2 pb-1 shrink-0" aria-hidden="true">
+          <div className="h-1 w-10 rounded-full bg-gray-300 dark:bg-gray-600" />
+        </div>
+
         {/* ヘッダー: mode tabs + close */}
         <div className="flex items-center justify-between px-3 py-2 shrink-0
                         bg-white dark:bg-gray-800

--- a/client/components/InventoryWorkspace.tsx
+++ b/client/components/InventoryWorkspace.tsx
@@ -206,16 +206,12 @@ export default function InventoryWorkspace({
     ? 'w-full'
     : 'max-w-6xl mx-auto transition-all duration-150 ease-out px-2 sm:px-4 md:px-6 lg:px-4';
 
-  // Chat サイドバー展開時の右余白:
-  // - embedded (PacksPage 配下): PacksPage main で padding-right を持つため適用不要
-  // - standalone (/p/:packId など): 自身で適用
-  const chatPaddingRight = !embedded && showChat && !isMobile ? '400px' : undefined;
+  // Chat は bottom sheet 化したため main に padding-right を差し込む必要はなくなった。
   const containerStyle = embedded
     ? undefined
     : {
         paddingTop: `${SPACING_SCALE.md}px`,
         paddingBottom: `${SPACING_SCALE.md}px`,
-        paddingRight: chatPaddingRight
       };
 
   const gearChartPanel = (

--- a/client/components/PacksPage.tsx
+++ b/client/components/PacksPage.tsx
@@ -3,10 +3,9 @@ import { useAuth } from '../utils/AuthContext';
 import { useAppState } from '../hooks/useAppState';
 import { usePacks } from '../hooks/usePacks';
 import { useProfile } from '../hooks/useProfile';
-import { useIsMobile } from '../hooks/useResponsiveSize';
 import InventoryWorkspace from './InventoryWorkspace';
 import ProfileHeader from './ProfileHeader';
-import ProfileEditorModal from './ProfileEditorModal';
+import SettingsModal from './SettingsModal';
 
 const fallbackUserId = 'local-user';
 
@@ -27,10 +26,10 @@ export default function PacksPage({
   onShowChat,
 }: PacksPageProps) {
   const { user } = useAuth();
-  const { gearItems, showChat } = appState;
+  const { gearItems } = appState;
   const { packs, createPack, updatePack, deletePack, toggleItemInPack, addItemsToPack } = usePacks(user?.id ?? fallbackUserId);
-  const { profile, updateField, showEditor, setShowEditor, plan } = useProfile(user?.name);
-  const isMobile = useIsMobile();
+  const { profile, updateField, plan } = useProfile(user?.name);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
 
@@ -68,23 +67,18 @@ export default function PacksPage({
     }
   };
 
-  // Chat が開いているデスクトップではサイドバー分の右余白を確保して、
-  // ProfileHeader の右端アイコン（Chat / Edit / Dark / Login）が隠れないようにする。
-  const chatSidebarGutter = showChat && !isMobile ? { paddingRight: '400px' } : undefined;
+  // Chat は bottom sheet 化したため、右余白を確保する必要はなし。
+  // main content は常時フル幅。
 
   return (
     <main
       id="inventory-overview"
-      className="max-w-6xl mx-auto min-h-screen px-1.5 pt-3 pb-4 sm:px-4 md:px-6 lg:px-4 transition-[padding] duration-200"
-      style={chatSidebarGutter}
+      className="max-w-6xl mx-auto min-h-screen px-1.5 pt-3 pb-4 sm:px-4 md:px-6 lg:px-4"
     >
       <div className="flex min-h-0 flex-col gap-3">
         <ProfileHeader
           profile={profile}
-          onEditProfile={() => setShowEditor(true)}
-          isAuthenticated={isAuthenticated}
-          userName={userName}
-          onLogout={onLogout}
+          onOpenSettings={() => setSettingsOpen(true)}
           onShowChat={onShowChat}
         />
 
@@ -109,12 +103,15 @@ export default function PacksPage({
         </div>
       </div>
 
-      {showEditor && (
-        <ProfileEditorModal
+      {settingsOpen && (
+        <SettingsModal
           profile={profile}
           onUpdate={updateField}
-          onClose={() => setShowEditor(false)}
+          onClose={() => setSettingsOpen(false)}
           plan={plan}
+          isAuthenticated={isAuthenticated}
+          userName={userName}
+          onLogout={onLogout}
         />
       )}
     </main>

--- a/client/components/ProfileEditorModal.tsx
+++ b/client/components/ProfileEditorModal.tsx
@@ -3,13 +3,6 @@ import type { ProfileSettings, UserPlan } from '../hooks/useProfile';
 import { useImageUpload } from '../hooks/useImageUpload';
 import { createCheckoutSession, createPortalSession } from '../services/billingService';
 
-interface ProfileEditorModalProps {
-  profile: ProfileSettings;
-  onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
-  onClose: () => void;
-  plan?: UserPlan;
-}
-
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <label className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{children}</label>
 );
@@ -69,7 +62,6 @@ const ImageDropZone: React.FC<{
 }> = ({ imageUrl, onSelect, onRemove, inputId, height = 'max-h-24' }) => {
   const { isDragging, imagePreview, handleDragOver, handleDragLeave, handleDrop, handleImageSelect, setPreview, removeImage } = useImageUpload();
 
-  // 既存画像をプレビューに反映
   useEffect(() => {
     setPreview(imageUrl || null);
   }, [imageUrl]);
@@ -120,6 +112,71 @@ const ImageDropZone: React.FC<{
   );
 };
 
+// ==================== Form (再利用可能な中身のみ) ====================
+
+interface ProfileEditorFormProps {
+  profile: ProfileSettings;
+  onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
+  plan?: UserPlan;
+}
+
+/**
+ * プロフィール編集フォーム本体 (モーダル chrome なし)。
+ * 単体モーダル (`ProfileEditorModal`) と統合 Settings (`SettingsModal`) の
+ * 両方から再利用される。
+ */
+export const ProfileEditorForm: React.FC<ProfileEditorFormProps> = ({ profile, onUpdate, plan = 'free' }) => (
+  <div className="space-y-3">
+    <div className="space-y-1.5">
+      <SectionLabel>Header</SectionLabel>
+      <input
+        className="input w-full"
+        placeholder="Packboard"
+        value={profile.headerTitle}
+        onChange={(e) => onUpdate('headerTitle', e.target.value)}
+      />
+      <ImageDropZone
+        imageUrl={profile.headerImageUrl}
+        onSelect={(base64) => onUpdate('headerImageUrl', base64)}
+        onRemove={() => onUpdate('headerImageUrl', '')}
+        inputId="profile-header-image"
+        height="max-h-20"
+      />
+    </div>
+    <div className="space-y-1.5">
+      <SectionLabel>Profile</SectionLabel>
+      <input
+        className="input w-full"
+        placeholder="Display name"
+        value={profile.displayName}
+        onChange={(e) => onUpdate('displayName', e.target.value)}
+      />
+      <input
+        className="input w-full"
+        placeholder="@handle"
+        value={profile.handle}
+        onChange={(e) => onUpdate('handle', e.target.value)}
+      />
+      <textarea
+        className="input w-full min-h-[64px]"
+        placeholder="Bio"
+        value={profile.bio}
+        onChange={(e) => onUpdate('bio', e.target.value)}
+      />
+    </div>
+    <PlanSection plan={plan} />
+  </div>
+);
+
+// ==================== Modal wrapper (後方互換) ====================
+
+interface ProfileEditorModalProps {
+  profile: ProfileSettings;
+  onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
+  onClose: () => void;
+  plan?: UserPlan;
+}
+
 const ProfileEditorModal: React.FC<ProfileEditorModalProps> = ({ profile, onUpdate, onClose, plan = 'free' }) => (
   <div className="modal-overlay" onClick={onClose}>
     <div className="modal-panel-lg" onClick={(e) => e.stopPropagation()}>
@@ -127,46 +184,9 @@ const ProfileEditorModal: React.FC<ProfileEditorModalProps> = ({ profile, onUpda
         <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Edit Profile</h3>
         <button type="button" className="text-gray-400 hover:text-gray-600" onClick={onClose}>✕</button>
       </div>
-      <div className="px-4 py-3 space-y-3">
-        <div className="space-y-1.5">
-          <SectionLabel>Header</SectionLabel>
-          <input
-            className="input w-full"
-            placeholder="Packboard"
-            value={profile.headerTitle}
-            onChange={(e) => onUpdate('headerTitle', e.target.value)}
-          />
-          <ImageDropZone
-            imageUrl={profile.headerImageUrl}
-            onSelect={(base64) => onUpdate('headerImageUrl', base64)}
-            onRemove={() => onUpdate('headerImageUrl', '')}
-            inputId="profile-header-image"
-            height="max-h-20"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <SectionLabel>Profile</SectionLabel>
-          <input
-            className="input w-full"
-            placeholder="Display name"
-            value={profile.displayName}
-            onChange={(e) => onUpdate('displayName', e.target.value)}
-          />
-          <input
-            className="input w-full"
-            placeholder="@handle"
-            value={profile.handle}
-            onChange={(e) => onUpdate('handle', e.target.value)}
-          />
-          <textarea
-            className="input w-full min-h-[64px]"
-            placeholder="Bio"
-            value={profile.bio}
-            onChange={(e) => onUpdate('bio', e.target.value)}
-          />
-        </div>
-        <PlanSection plan={plan} />
-        <div className="flex items-center justify-end pt-1">
+      <div className="px-4 py-3">
+        <ProfileEditorForm profile={profile} onUpdate={onUpdate} plan={plan} />
+        <div className="flex items-center justify-end pt-3">
           <button type="button" className="btn-primary" onClick={onClose}>Done</button>
         </div>
       </div>

--- a/client/components/ProfileHeader.tsx
+++ b/client/components/ProfileHeader.tsx
@@ -1,33 +1,23 @@
-import React, { useRef, useState } from 'react';
+import React from 'react';
 import type { ProfileSettings } from '../hooks/useProfile';
-import { useDarkMode } from '../hooks/useDarkMode';
-import { useOutsideClick } from '../hooks/useOutsideClick';
 
 interface ProfileHeaderProps {
   profile: ProfileSettings;
-  onEditProfile: () => void;
-  // AppDock から移植するコントロール
-  isAuthenticated: boolean;
-  userName?: string;
-  onLogout: () => void;
+  onOpenSettings: () => void;
   onShowChat?: () => void;
 }
 
-const ProfileHeader: React.FC<ProfileHeaderProps> = ({
-  profile,
-  onEditProfile,
-  isAuthenticated,
-  userName,
-  onLogout,
-  onShowChat,
-}) => {
-  const { isDark, toggle: toggleDarkMode } = useDarkMode();
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const userMenuRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(userMenuRef, () => setUserMenuOpen(false), userMenuOpen);
-
-  const userInitial = (userName?.trim()?.charAt(0) || 'U').toUpperCase();
-
+/**
+ * ProfileHeader — 画面上部のプロフィール表示 + 操作コントロール。
+ *
+ * アイコンは **Chat / Settings の 2 つ** に集約:
+ * - Chat: bottom sheet 形式の ChatSidebar を開く
+ * - Settings: tab モーダル (Profile / Account) を開く
+ *
+ * ダークモード切替は `ThemeToggleFab` (viewport 右上 fixed) に分離済み。
+ * Profile 編集 / Logout は Settings モーダルに統合済み。
+ */
+const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, onOpenSettings, onShowChat }) => {
   return (
     <section className="card overflow-hidden">
       {profile.headerImageUrl && (
@@ -53,11 +43,8 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
           </div>
         </div>
 
-        {/* 右: コントロール群
-         * - Chat / Edit Profile / Dark mode は常時表示
-         * - 未ログイン時: Login ボタンを直接表示（メニューに埋め込まない）
-         * - ログイン済み: avatar → User menu（userName + Logout のみ） */}
-        <div ref={userMenuRef} className="relative flex items-center gap-1">
+        {/* 右: Chat + Settings の 2 アイコン */}
+        <div className="flex items-center gap-1">
           {onShowChat && (
             <button
               type="button"
@@ -74,68 +61,16 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({
 
           <button
             type="button"
-            onClick={onEditProfile}
+            onClick={onOpenSettings}
             className="icon-btn"
-            aria-label="Edit Profile"
-            title="Edit Profile"
+            aria-label="Open settings"
+            title="Settings"
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
           </button>
-
-          <button
-            type="button"
-            onClick={toggleDarkMode}
-            className="icon-btn"
-            aria-label="Toggle dark mode"
-            title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-          >
-            {isDark ? (
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
-              </svg>
-            )}
-          </button>
-
-          {/* ユーザーメニュー: 未認証時は Landing 画面を表示するため、
-           * ProfileHeader は常に認証済み前提。ログアウトのみを持つ。 */}
-          {isAuthenticated && (
-            <>
-              <button
-                type="button"
-                onClick={() => setUserMenuOpen((p) => !p)}
-                className="icon-btn"
-                aria-label="User menu"
-                title={userName || 'User'}
-              >
-                <span className="h-5 w-5 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-2xs font-semibold inline-flex items-center justify-center">
-                  {userInitial}
-                </span>
-              </button>
-
-              {userMenuOpen && (
-                <div className="absolute right-0 top-full mt-2 w-44 rounded-md bg-white dark:bg-gray-800 shadow-sm overflow-hidden z-50">
-                  {userName && (
-                    <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-300 border-b border-gray-100 dark:border-gray-700 truncate">
-                      {userName}
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    onClick={() => { onLogout(); setUserMenuOpen(false); }}
-                  >
-                    Logout
-                  </button>
-                </div>
-              )}
-            </>
-          )}
         </div>
       </div>
     </section>

--- a/client/components/SettingsModal.tsx
+++ b/client/components/SettingsModal.tsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+import type { ProfileSettings, UserPlan } from '../hooks/useProfile';
+import { ProfileEditorForm } from './ProfileEditorModal';
+
+interface SettingsModalProps {
+  profile: ProfileSettings;
+  onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
+  onClose: () => void;
+  plan?: UserPlan;
+  isAuthenticated: boolean;
+  userName?: string;
+  onLogout: () => void;
+}
+
+type SettingsTab = 'profile' | 'account';
+
+/**
+ * Settings モーダル — Profile / Account を tab で統合。
+ *
+ * Profile tab は既存の `ProfileEditorForm` を再利用。
+ * Account tab はログイン済みユーザー情報 + Logout。
+ *
+ * Tab UI は `ChatSidebar` の Add / Advisor と同じ視覚言語を踏襲。
+ */
+const SettingsModal: React.FC<SettingsModalProps> = ({
+  profile,
+  onUpdate,
+  onClose,
+  plan = 'free',
+  isAuthenticated,
+  userName,
+  onLogout,
+}) => {
+  const [tab, setTab] = useState<SettingsTab>('profile');
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-panel-md" onClick={(e) => e.stopPropagation()}>
+        {/* Header: tab bar + close */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
+          <div role="tablist" aria-label="Settings section" className="inline-flex items-center gap-0.5 p-0.5 rounded-md bg-gray-100 dark:bg-gray-700">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'profile'}
+              onClick={() => setTab('profile')}
+              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
+                          ${tab === 'profile'
+                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
+                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
+            >
+              Profile
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'account'}
+              onClick={() => setTab('account')}
+              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
+                          ${tab === 'account'
+                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
+                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
+            >
+              Account
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close settings"
+            className="h-8 w-8 inline-flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-4 py-3">
+          {tab === 'profile' && (
+            <ProfileEditorForm profile={profile} onUpdate={onUpdate} plan={plan} />
+          )}
+          {tab === 'account' && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                  Signed in as
+                </label>
+                <p className="text-sm text-gray-900 dark:text-gray-100">
+                  {isAuthenticated ? (userName ?? 'User') : 'Not signed in'}
+                </p>
+              </div>
+              {isAuthenticated && (
+                <div className="pt-2">
+                  <button
+                    type="button"
+                    className="btn-secondary w-full"
+                    onClick={() => {
+                      onLogout();
+                      onClose();
+                    }}
+                  >
+                    Logout
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-end">
+          <button type="button" className="btn-primary" onClick={onClose}>
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default React.memo(SettingsModal);

--- a/client/components/ThemeToggleFab.tsx
+++ b/client/components/ThemeToggleFab.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDarkMode } from '../hooks/useDarkMode';
+
+/**
+ * ThemeToggleFab — viewport 右上に fixed の ghost ボタン。
+ *
+ * カード / ヘッダーの外側に独立配置することで、どの画面でも
+ * 同じ位置からダークモード切替にアクセスできる。
+ *
+ * z-index は modal-overlay (z-50) より下の 30 にして、
+ * モーダル open 時は背後に潜むようにする。
+ */
+const ThemeToggleFab: React.FC = () => {
+  const { isDark, toggle } = useDarkMode();
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className="fixed top-2 right-2 z-30 h-7 w-7 inline-flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:bg-[var(--overlay-hover)] active:bg-[var(--overlay-active)] transition-colors"
+    >
+      {isDark ? (
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export default React.memo(ThemeToggleFab);


### PR DESCRIPTION
## Summary

ヘッダーのアイコン過多・Chat の main 圧迫・設定系 UI の散在を解消する UI 再編。

### ビフォー → アフター

| 要素 | Before | After |
|-----|--------|-------|
| ProfileHeader のアイコン | Chat / Edit / Theme / Avatar (4) | Chat / Settings (2) |
| 設定系の入口 | 鉛筆 (Edit) + avatar menu (Logout) が別場所 | Settings ボタン 1 つ → tab モーダルで Profile / Account |
| Theme toggle | ヘッダー card 内 | viewport 右上 fixed (`top: 8px; right: 8px`) |
| Chat パネル | 右 fixed 400px + main を 400px 圧迫 | 下部 bottom sheet (70vh) + backdrop-blur、main 非干渉 |

### 主な変更
- **ProfileHeader**: Chat + Settings の 2 アイコン構成。Edit / Theme / User menu を撤去
- **SettingsModal** (新規): `.modal-panel-md` ベース。Profile / Account tab (ChatSidebar と同じ視覚言語)
- **ThemeToggleFab** (新規): ghost button、全ルートで viewport 右上固定、z-index 30 でモーダル背後に潜む
- **ChatSidebar**: `translateX` → `translateY` で bottom sheet 化。grabber bar + border-top-radius + backdrop-blur
- **ProfileEditorModal**: フォーム本体を `ProfileEditorForm` として export → SettingsModal で再利用
- **`chatPaddingRight: 400px`** ロジック (PacksPage / InventoryWorkspace) を撤去 → Chat 開閉で chart/table がリサイズされない

### 既存デザイントークンの再利用
`.modal-overlay` / `.modal-panel-md` / `.icon-btn` / `--overlay-hover` / `--overlay-active` / `--radius-surface` / `useDarkMode()`

### スコープ外 (後続 PR 候補)
- Chat の grabber ドラッグによる height 調整 / close
- Settings の Preferences tab (weight unit / 通貨)
- `AppDock` (`/p/:packId` ルート) の同等再編

## Test plan

- [x] `npm run lint` 成功
- [x] `npm run build` 成功
- [x] ローカルで以下を目視確認:
  - ProfileHeader: Chat + Settings の 2 アイコンのみ
  - Theme toggle が viewport 右上に常駐、クリックで dark ⇔ light 切替
  - Settings クリックで tab モーダル open、Profile tab に既存編集 UI、Account tab に username + Logout
  - Chat クリックで bottom sheet が 70vh で下からスライドイン、backdrop-blur 越しに chart が見える
  - Chat 開閉時に main content がリサイズされない
- [ ] モバイル (viewport 360px) で bottom sheet が 85vh で full-width 表示 (要目視)

🤖 Generated with [Claude Code](https://claude.com/claude-code)