### PR TITLE
feat(ui): Chat を右スライド + ガラス FloatingChatInput に刷新 + 履歴 / Compare / トークン整合 / Chart モバイル最適化

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port", "3010", "--strictPort"],
+      "port": 3010
+    }
+  ]
+}

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -15,6 +15,8 @@ export default function App() {
   const { user, isAuthenticated, logout, loginWithEmail } = useAuth();
   const appState = useAppState();
   const { setShowChat } = appState;
+  // App.tsx は AppDock (PackDetailPage) の Chat ボタン用に setShowChat だけ参照する。
+  // PacksPage 側は FloatingChatInput で起動するため onShowChat は不要。
 
   const { messages, removeNotification, showError } = useNotifications();
 
@@ -68,7 +70,6 @@ export default function App() {
               isAuthenticated={isAuthenticated}
               userName={user?.name}
               onLogout={logout}
-              onShowChat={() => setShowChat((prev) => !prev)}
             />
           }
         />

--- a/client/components/AppDock.tsx
+++ b/client/components/AppDock.tsx
@@ -31,11 +31,18 @@ const AppDock: React.FC<AppDockProps> = ({
 
   return (
     <div className="fixed top-3 right-3 z-[70] pointer-events-none">
-      <div ref={dockRef} className="pointer-events-auto relative flex items-center gap-1 rounded-lg shadow-sm bg-white px-1.5 py-1.5 dark:bg-gray-900">
+      <div
+        ref={dockRef}
+        className="pointer-events-auto relative flex items-center gap-1 px-1.5 py-1.5 rounded-surface has-noise"
+        style={{ background: 'var(--surface-level-0)', boxShadow: 'var(--shadow-sm)', border: 'var(--border-default)' }}
+      >
         {location.pathname.startsWith('/p/') && (
           <a
             href="/"
-            className="h-control-lg sm:h-control px-2.5 sm:px-3 rounded-control text-xs font-medium text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 inline-flex items-center gap-1.5 transition-colors"
+            className="h-control-lg sm:h-control px-2.5 sm:px-3 rounded-control text-xs font-medium inline-flex items-center gap-1.5 transition-colors"
+            style={{ color: 'var(--ink-secondary)' }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLAnchorElement).style.background = 'var(--surface-level-1)'; }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLAnchorElement).style.background = 'transparent'; }}
           >
             <svg className="w-4 h-4 sm:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
@@ -47,7 +54,8 @@ const AppDock: React.FC<AppDockProps> = ({
         {onShowChat && (
           <button
             type="button"
-            className="glass-header-chip h-control-lg sm:h-control px-2.5 sm:px-3 inline-flex items-center justify-center gap-1.5 text-gray-600 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-700 text-xs font-medium"
+            className="glass-header-chip h-control-lg sm:h-control px-2.5 sm:px-3 inline-flex items-center justify-center gap-1.5 text-xs font-medium"
+            style={{ color: 'var(--ink-secondary)' }}
             onClick={onShowChat}
             aria-label="Open chat (Add / Advisor)"
             title="Chat — add gear & advisor"
@@ -66,26 +74,39 @@ const AppDock: React.FC<AppDockProps> = ({
           <div className="hidden sm:block relative">
             <button
               type="button"
-              className="glass-header-chip h-control min-w-control px-1.5 inline-flex items-center justify-center text-gray-600 dark:text-gray-200 hover:bg-white dark:hover:bg-gray-700"
+              className="glass-header-chip h-control min-w-control px-1.5 inline-flex items-center justify-center"
+              style={{ color: 'var(--ink-secondary)' }}
               onClick={() => setUserMenuOpen((prev) => !prev)}
               aria-label="User menu"
               title={userName || 'User'}
             >
-              <span className="h-6 w-6 rounded-full bg-gray-700 dark:bg-gray-200 text-white dark:text-gray-900 text-2xs font-semibold inline-flex items-center justify-center">
+              <span
+                className="h-6 w-6 rounded-full text-2xs font-semibold inline-flex items-center justify-center"
+                style={{ background: 'var(--mondrian-black)', color: 'var(--ink-inverse)' }}
+              >
                 {userInitial}
               </span>
             </button>
 
             {userMenuOpen && (
-              <div className="absolute right-0 top-full mt-2 w-44 rounded-md bg-white dark:bg-gray-800 shadow-sm overflow-hidden">
+              <div
+                className="card absolute right-0 top-full mt-2 w-44 overflow-hidden"
+                style={{ borderRadius: 'var(--radius-control)', boxShadow: 'var(--shadow-md)' }}
+              >
                 {userName && (
-                  <div className="px-3 py-2 text-xs text-gray-500 dark:text-gray-300 border-b border-gray-200 truncate">
+                  <div
+                    className="px-3 py-2 text-xs truncate"
+                    style={{ color: 'var(--ink-muted)', borderBottom: 'var(--border-divider)' }}
+                  >
                     {userName}
                   </div>
                 )}
                 <button
                   type="button"
-                  className="w-full text-left px-3 py-2 text-xs text-gray-700 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                  className="w-full text-left px-3 py-2 text-xs transition-colors"
+                  style={{ color: 'var(--ink-primary)' }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-level-1)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
                   onClick={() => {
                     onLogout();
                     setUserMenuOpen(false);

--- a/client/components/ChartPanel.tsx
+++ b/client/components/ChartPanel.tsx
@@ -287,7 +287,7 @@ const ChartPanel: React.FC<ChartPanelProps> = React.memo(({
   return (
     <div className="lg:h-[calc(100vh-100px)] flex flex-col">
       {/* メインコンテンツ - 統合レイアウト */}
-      <div className="flex-1 flex flex-col lg:flex-row gap-3 min-h-0 lg:overflow-hidden">
+      <div className="flex-1 flex flex-col lg:flex-row gap-2 lg:gap-3 min-h-0 lg:overflow-hidden">
         {/* グラフエリア */}
         <Card className={`flat-panel flex flex-col min-w-0 flex-shrink-0 transition-all duration-300 ${
           isChartCollapsed

--- a/client/components/ChatSidebar.tsx
+++ b/client/components/ChatSidebar.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import {
   extractFromPrompt,
   enhanceUrlDataWithPrompt,
-  extractCategoryFromPrompt,
   extractFromUrl,
   APIError,
 } from '../services/llmService';
@@ -10,58 +9,63 @@ import { useWeightUnit } from '../contexts/WeightUnitContext';
 import { formatWeight, formatWeightLarge } from '../utils/weightUnit';
 import { formatPrice } from '../utils/formatters';
 import { useIsMobile } from '../hooks/useResponsiveSize';
+import { useOutsideClick } from '../hooks/useOutsideClick';
 import { useAdvisorChat, useAdvisorPanel, SuggestedEditWithState } from '../hooks/useAdvisorChat';
 import type { GearAdvisorContext, GearRef } from '../services/llmAdvisor';
+import type { AdvisorSession } from '../services/advisorSessionsApi';
+import CompactComparisonPanel from './CompactComparisonPanel';
 
 /**
- * ChatSidebar — Chat 中心 UX の統合サイドバー
+ * ChatSidebar — 1 本化された AI チャットサイドバー
  *
- * 2 モードを tabs で切替:
- * - **Add**: URL 貼付 or ブランド+商品名で LLM 抽出 → ギアリストに追加
- * - **Advisor**: 装備最適化の対話（base weight 削減、Big 3 分析、編集提案+Undo）
- *
- * 旧 ChatPopup / GearForm / GearInputModal / UrlBulkImportModal / GearAdvisorChat を
- * ここに集約。AppDock / ProfileHeader のトグルボタンは 1 つに統一される。
+ * Chat は Advisor パイプライン（SSE / DB 永続化 / suggestedEdits / gearRefs）で統一。
+ * 入力欄左の「+」から Import gear / Compare を呼び出す。
+ * Compare を押すと現在スコープのギアをピックし、チャット内にミニ比較パネルが挿入される。
  */
 
 // ==================== 共通定義 ====================
 
-type ChatMode = 'add' | 'advisor';
+type InputMode = 'chat' | 'import' | 'compare';
 
-interface AddChatMessage {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-  timestamp: Date;
-}
-
-type PromptType = 'url' | 'add_gear' | 'add_category' | 'url_with_prompt' | 'multiple_urls' | 'general';
+type PromptType = 'url' | 'add_gear' | 'url_with_prompt' | 'multiple_urls' | 'general';
 
 interface ChatSidebarProps {
   isOpen: boolean;
   onClose: () => void;
-  /** Add モード: LLM 抽出結果を親にコールバック */
+  /** Import gear: LLM 抽出結果を親にコールバック（親で DB 保存 + 通知） */
   onGearExtracted?: (gearData: any) => void;
   categories?: any[];
   existingItemCount?: number;
-  /** Advisor モード: コンテキスト / 編集 apply / gear ジャンプ */
+  /** Advisor: コンテキスト / 編集 apply / gear ジャンプ */
   advisorContext?: GearAdvisorContext;
   onApplyEdit?: (gearId: string, field: string, value: unknown) => Promise<void>;
   onFocusGear?: (gearId: string) => void;
+  /** Import の進捗・エラーを親の通知システムに流すコールバック */
+  onNotify?: (type: 'success' | 'error' | 'info', message: string) => void;
+  /**
+   * FloatingChatInput から届いた初回プロンプト。
+   * nonce で同一テキストの連続送信を別イベントとして扱う。
+   */
+  initialAdvisorPrompt?: { text: string; nonce: number } | null;
+  /** initialAdvisorPrompt を消費したら呼ぶ */
+  onAdvisorPromptConsumed?: () => void;
 }
 
 const TIME_FMT = new Intl.DateTimeFormat('en-US', { hour: '2-digit', minute: '2-digit' });
 
-// ==================== Add モードのヘルパー ====================
+/** 履歴ドロップダウン用の相対時間表記 */
+const formatRelativeTime = (iso: string): string => {
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return '';
+  const diffSec = Math.max(0, (Date.now() - t) / 1000);
+  if (diffSec < 60) return 'just now';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h`;
+  if (diffSec < 604800) return `${Math.floor(diffSec / 86400)}d`;
+  return new Date(iso).toLocaleDateString();
+};
 
-const buildInitialAddMessage = (hasItems: boolean): AddChatMessage => ({
-  id: 'initial-add',
-  role: 'assistant',
-  content: hasItems
-    ? 'Paste a URL, describe a product ("Arc\'teryx Beta AR"), or ask to create a category. I will extract the details and add it to your list.'
-    : '👋 Welcome! Add your first gear by:\n\n• Pasting a product URL (single or multiple)\n• Typing a brand + product name\n  e.g. "Patagonia Houdini 100g"\n• Describing a category\n  e.g. "Shelter category"\n\nI will extract the details and add it to your list.',
-  timestamp: new Date(),
-});
+// ==================== Import helpers ====================
 
 const extractMultipleUrls = (text: string): string[] => {
   const urlRegex = /https?:\/\/[^\s]+/g;
@@ -80,18 +84,16 @@ const BRAND_PATTERNS = [
 const containsBrand = (prompt: string): boolean =>
   BRAND_PATTERNS.some((brand) => prompt.toLowerCase().includes(brand.toLowerCase()));
 
-const classifyPrompt = (prompt: string): PromptType => {
+const classifyImportPrompt = (prompt: string): PromptType => {
   const urls = extractMultipleUrls(prompt);
-  const lowerPrompt = prompt.toLowerCase();
   if (urls.length > 1) return 'multiple_urls';
   if (urls.length === 1 && prompt.length > urls[0].length + 10) return 'url_with_prompt';
   if (urls.length === 1 && /^https?:\/\/.+$/.test(prompt.trim())) return 'url';
-  if (lowerPrompt.includes('category') || lowerPrompt.includes('カテゴリ')) return 'add_category';
   if (containsBrand(prompt)) return 'add_gear';
   return 'general';
 };
 
-// ==================== Advisor モードのサブコンポーネント ====================
+// ==================== Advisor サブコンポーネント ====================
 
 const QUICK_PROMPTS = [
   { icon: '⚡', label: 'Reduce base weight', prompt: 'How can I reduce my base weight? Focus on the heaviest items and suggest specific lighter alternatives.' },
@@ -123,10 +125,8 @@ const GearRefChip: React.FC<{ ref_: GearRef; onClick: (gearId: string) => void }
     type="button"
     onClick={() => onClick(ref_.gearId)}
     title={`Jump to ${ref_.gearName}`}
-    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
-               bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200
-               border border-gray-200 dark:border-gray-600
-               hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+    className="glass-header-chip h-badge px-2 gap-1 text-xs font-medium"
+    style={{ color: 'var(--ink-secondary)' }}
   >
     <svg className="w-3 h-3 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <circle cx="11" cy="11" r="8" />
@@ -147,35 +147,30 @@ const SuggestedEditCard: React.FC<{
   const isApplied = edit._applied === true;
   const isBusy = applyingKey === editKey;
   return (
-    <div className={`p-3 rounded-md mt-2 shadow-sm border text-xs
-                     ${isApplied
-                       ? 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
-                       : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600'}`}>
-      <p className="font-semibold mb-1 text-gray-500 dark:text-gray-400">
+    <div className="card p-3 mt-2 text-xs">
+      <p className="font-semibold mb-1" style={{ color: 'var(--ink-muted)' }}>
         Suggestion: {edit.gearName}
       </p>
-      <p className="mb-1 text-gray-800 dark:text-gray-200">
-        <span className="text-gray-500 dark:text-gray-400">{FIELD_LABELS[edit.field] ?? edit.field}: </span>
-        <span className="line-through text-gray-400 dark:text-gray-500">{formatEditValue(edit.field, edit.currentValue, weightUnit)}</span>
+      <p className="mb-1" style={{ color: 'var(--ink-primary)' }}>
+        <span style={{ color: 'var(--ink-muted)' }}>{FIELD_LABELS[edit.field] ?? edit.field}: </span>
+        <span className="line-through" style={{ color: 'var(--ink-disabled)' }}>{formatEditValue(edit.field, edit.currentValue, weightUnit)}</span>
         {' → '}
         <span className="font-medium">{formatEditValue(edit.field, edit.suggestedValue, weightUnit)}</span>
       </p>
-      <p className="mb-2 text-gray-500 dark:text-gray-400">{edit.reason}</p>
+      <p className="mb-2" style={{ color: 'var(--ink-muted)' }}>{edit.reason}</p>
       {isApplied ? (
-        <div className="flex gap-2">
-          <span className="flex-1 py-1.5 rounded-lg text-xs font-medium text-center
-                           bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
+        <div className="flex items-center gap-2">
+          <span
+            className="flex-1 inline-flex items-center justify-center h-badge rounded-badge text-2xs font-medium uppercase tracking-wide"
+            style={{ background: 'var(--surface-level-2)', color: 'var(--ink-muted)' }}
+          >
             Applied
           </span>
           <button
             type="button"
             disabled={isBusy}
             onClick={onUndo}
-            className="px-3 py-1.5 rounded-lg text-xs font-medium
-                       text-gray-600 dark:text-gray-300
-                       border border-gray-300 dark:border-gray-600
-                       hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors
-                       disabled:opacity-50 disabled:cursor-not-allowed"
+            className="btn-secondary btn-xs disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isBusy ? 'Undoing…' : 'Undo'}
           </button>
@@ -185,9 +180,7 @@ const SuggestedEditCard: React.FC<{
           type="button"
           disabled={isBusy}
           onClick={onApply}
-          className="w-full py-1.5 rounded-lg text-xs font-medium transition-opacity
-                     hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed
-                     bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900"
+          className="btn-primary btn-xs w-full disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isBusy ? 'Applying…' : 'Apply change'}
         </button>
@@ -205,7 +198,7 @@ const FALLBACK_ADVISOR_CONTEXT: GearAdvisorContext = {
   packName: null,
 };
 
-const noopApplyEdit = async () => { /* no-op: Advisor mode 不要時の placeholder */ };
+const noopApplyEdit = async () => { /* no-op: onApplyEdit 未指定時の placeholder */ };
 
 const ChatSidebar: React.FC<ChatSidebarProps> = ({
   isOpen,
@@ -216,245 +209,194 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
   advisorContext,
   onApplyEdit,
   onFocusGear,
+  onNotify,
+  initialAdvisorPrompt,
+  onAdvisorPromptConsumed,
 }) => {
   const { unit: weightUnit } = useWeightUnit();
   const isMobile = useIsMobile();
-  const [mode, setMode] = useState<ChatMode>('add');
 
-  // --- Add モード ローカル state ---
-  const [addMessages, setAddMessages] = useState<AddChatMessage[]>(() => [
-    buildInitialAddMessage(existingItemCount > 0),
-  ]);
-  const [addInput, setAddInput] = useState('');
-  const [addIsLoading, setAddIsLoading] = useState(false);
-  const addMessagesEndRef = useRef<HTMLDivElement>(null);
-  const addInputRef = useRef<HTMLTextAreaElement>(null);
-
-  // existingItemCount は非同期で後からロードされるため、ユーザーがまだ
-  // 発話していない（初回メッセージ 1 件だけの）状態であれば welcome 文言を
-  // items 数に追従させる。
-  useEffect(() => {
-    setAddMessages((prev) => {
-      if (prev.length === 1 && prev[0].id === 'initial-add') {
-        return [buildInitialAddMessage(existingItemCount > 0)];
-      }
-      return prev;
-    });
-  }, [existingItemCount]);
-
-  // --- Advisor モード hook （常に呼び出す：hook 順序安定のため） ---
+  // --- Advisor hook ---
   const advisor = useAdvisorChat(
     advisorContext ?? FALLBACK_ADVISOR_CONTEXT,
     onApplyEdit ?? noopApplyEdit,
   );
-  const { messagesEndRef: advisorMessagesEndRef, inputRef: advisorInputRef } =
-    useAdvisorPanel(isOpen && mode === 'advisor', advisor.messages);
+  const { messagesEndRef, inputRef } = useAdvisorPanel(isOpen, advisor.messages);
+  const advisorLastAssistantId = advisor.messages.filter((m) => m.role === 'assistant').at(-1)?.id;
 
-  const isAdvisorAvailable = !!advisorContext && !!onApplyEdit;
+  // --- 入力モード ---
+  const [inputMode, setInputMode] = useState<InputMode>('chat');
+  const [importText, setImportText] = useState('');
+  const [importBusy, setImportBusy] = useState(false);
+  const [compareSelection, setCompareSelection] = useState<Set<string>>(() => new Set());
 
-  // Add モード: 自動スクロール + オープン時フォーカス
-  useEffect(() => {
-    if (mode === 'add') {
-      addMessagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [addMessages, mode]);
+  // --- + ポップオーバー ---
+  const [plusMenuOpen, setPlusMenuOpen] = useState(false);
+  const plusMenuRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(plusMenuRef, () => setPlusMenuOpen(false), plusMenuOpen);
 
-  useEffect(() => {
-    if (isOpen && mode === 'add') {
-      setTimeout(() => addInputRef.current?.focus(), 150);
-    }
-  }, [isOpen, mode]);
+  // --- 履歴ドロップダウン ---
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historySessions, setHistorySessions] = useState<AdvisorSession[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const historyRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(historyRef, () => setHistoryOpen(false), historyOpen);
 
-  // ==================== Add モード: 送信処理 ====================
-  const handleAddSend = async () => {
-    if (!addInput.trim() || addIsLoading) return;
-
-    const userMessage: AddChatMessage = {
-      id: Date.now().toString(),
-      role: 'user',
-      content: addInput.trim(),
-      timestamp: new Date(),
-    };
-    setAddMessages((prev) => [...prev, userMessage]);
-    const currentInput = addInput.trim();
-    setAddInput('');
-    setAddIsLoading(true);
-
+  // advisor オブジェクト全体を依存に取ると毎レンダー再 fetch されてしまうため、
+  // 安定参照の listSessions だけを抜き出して依存に置く。
+  const advisorListSessions = advisor.listSessions;
+  const refreshHistory = useCallback(async () => {
+    setHistoryLoading(true);
     try {
-      let assistantResponse = '';
-      let shouldExtractGear = false;
-      let mockGearData: any = null;
-      const promptType = classifyPrompt(currentInput);
-
-      switch (promptType) {
-        case 'url':
-          try {
-            const extractedData = await extractFromUrl(currentInput, categories);
-            const matchedCategory = categories.find((cat) => cat.name === extractedData.suggestedCategory);
-            assistantResponse = `Extracted from URL!\n\nProduct: ${extractedData.name}\nBrand: ${extractedData.brand || 'Unknown'}\nWeight: ${extractedData.weightGrams ? formatWeight(extractedData.weightGrams, weightUnit) : 'Estimating...'}\nPrice: ${extractedData.priceCents ? formatPrice(extractedData.priceCents) : 'Estimating...'}\nCategory: ${extractedData.suggestedCategory}\n\nAdded to your list.`;
-            shouldExtractGear = true;
-            mockGearData = {
-              name: extractedData.name, brand: extractedData.brand, productUrl: currentInput,
-              categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
-              weightGrams: extractedData.weightGrams, priceCents: extractedData.priceCents,
-              season: '', priority: 3,
-            };
-          } catch (error) {
-            assistantResponse = error instanceof APIError
-              ? `URL parse error: ${error.message}`
-              : `URL parse error: ${error instanceof Error ? error.message : 'Failed to extract'}`;
-          }
-          break;
-
-        case 'add_gear':
-          try {
-            const extractedData = await extractFromPrompt(currentInput, categories);
-            const matchedCategory = categories.find((cat) => cat.name === extractedData.suggestedCategory);
-            assistantResponse = `Gear info extracted!\n\nProduct: ${extractedData.name}\nBrand: ${extractedData.brand || 'Unknown'}\nWeight: ${extractedData.weightGrams ? formatWeight(extractedData.weightGrams, weightUnit) : 'Estimating...'}\nPrice: ${extractedData.priceCents ? formatPrice(extractedData.priceCents) : 'Estimating...'}\nCategory: ${extractedData.suggestedCategory}\n\nAdded to your list.`;
-            shouldExtractGear = true;
-            mockGearData = {
-              name: extractedData.name, brand: extractedData.brand, productUrl: '',
-              categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
-              weightGrams: extractedData.weightGrams, priceCents: extractedData.priceCents,
-              season: '', priority: 3,
-            };
-          } catch (error) {
-            assistantResponse = error instanceof APIError
-              ? `Extraction error: ${error.message}`
-              : `Extraction error: ${error instanceof Error ? error.message : 'Please use "Brand + Product" format.'}`;
-          }
-          break;
-
-        case 'add_category':
-          try {
-            const categoryData = await extractCategoryFromPrompt(currentInput);
-            assistantResponse = categoryData
-              ? `Category created!\n\nCategory: ${categoryData.englishName}\nJapanese: ${categoryData.name}`
-              : 'Could not identify category. Example: "Shelter category"';
-          } catch (error) {
-            assistantResponse = error instanceof APIError
-              ? `Category error: ${error.message}`
-              : `Category error: ${error instanceof Error ? error.message : 'Failed to create'}`;
-          }
-          break;
-
-        case 'url_with_prompt':
-          try {
-            const urlMatch = currentInput.match(/(https?:\/\/[^\s]+)/);
-            if (urlMatch) {
-              const url = urlMatch[1];
-              const urlData = await extractFromUrl(url, categories);
-              const enhancedData = await enhanceUrlDataWithPrompt(urlData, currentInput);
-              const matchedCategory = categories.find((cat) => cat.name === enhancedData.suggestedCategory);
-              assistantResponse = `Processed URL with extra info!\n\nProduct: ${enhancedData.name}\nBrand: ${enhancedData.brand}\nWeight: ${formatWeight(enhancedData.weightGrams ?? null, weightUnit)}\nPrice: ${formatPrice(enhancedData.priceCents)}\nCategory: ${enhancedData.suggestedCategory}\n\nAdded to your list.`;
-              shouldExtractGear = true;
-              mockGearData = {
-                name: enhancedData.name, brand: enhancedData.brand, productUrl: url,
-                categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
-                weightGrams: enhancedData.weightGrams, priceCents: enhancedData.priceCents,
-                season: '', priority: 3,
-              };
-            } else {
-              assistantResponse = 'URL not detected. Example: "https://… + 230g"';
-            }
-          } catch (error) {
-            assistantResponse = error instanceof APIError
-              ? `URL+info error: ${error.message}`
-              : `URL+info error: ${error instanceof Error ? error.message : 'Failed to process'}`;
-          }
-          break;
-
-        case 'multiple_urls':
-          try {
-            const urls = extractMultipleUrls(currentInput);
-            assistantResponse = `${urls.length} URLs detected. Processing in parallel...\n\n`;
-            const results = await Promise.allSettled(urls.map((url) => extractFromUrl(url, categories)));
-            const successResults: any[] = [];
-            const failedUrls: string[] = [];
-            results.forEach((result, index) => {
-              if (result.status === 'fulfilled') {
-                const data = result.value;
-                const isFallback = data.source === 'fallback' ||
-                  !data.name || data.name.includes('Failed') || data.name.includes('Product from');
-                if (!isFallback) successResults.push({ url: urls[index], data });
-                else failedUrls.push(urls[index]);
-              } else {
-                failedUrls.push(urls[index]);
-              }
-            });
-            if (successResults.length > 0) {
-              assistantResponse += `✅ Success: ${successResults.length} items\n\n`;
-              successResults.forEach((item, idx) => {
-                assistantResponse += `${idx + 1}. ${item.data.name}\n`;
-                assistantResponse += `   Brand: ${item.data.brand || 'Unknown'}\n`;
-                assistantResponse += `   Weight: ${item.data.weightGrams ? formatWeight(item.data.weightGrams, weightUnit) : '?'}\n`;
-                assistantResponse += `   Price: ${item.data.priceCents ? formatPrice(item.data.priceCents) : '?'}\n\n`;
-              });
-              shouldExtractGear = true;
-              mockGearData = successResults.map((item) => {
-                const matchedCategory = categories.find((cat) => cat.name === item.data.suggestedCategory);
-                return {
-                  name: item.data.name, brand: item.data.brand, productUrl: item.url,
-                  imageUrl: item.data.imageUrl, categoryId: matchedCategory?.id,
-                  requiredQuantity: 1, ownedQuantity: 0,
-                  weightGrams: item.data.weightGrams, priceCents: item.data.priceCents,
-                  season: '', priority: 3,
-                };
-              });
-            }
-            if (failedUrls.length > 0) {
-              assistantResponse += `\n❌ Failed: ${failedUrls.length}\n`;
-              failedUrls.forEach((url, idx) => {
-                assistantResponse += `  ${idx + 1}. ${url.substring(0, 50)}...\n`;
-              });
-            }
-            assistantResponse += `\n${successResults.length} items added.`;
-          } catch (error) {
-            assistantResponse = error instanceof APIError
-              ? `Batch error: ${error.message}`
-              : `Batch error: ${error instanceof Error ? error.message : 'Unexpected error'}`;
-          }
-          break;
-
-        default:
-          assistantResponse =
-            'Tell me more:\n\n• "Brand + Product name" (e.g. "Arc\'teryx Beta AR")\n• Paste a product URL\n• "Shelter category" to create a category';
-          break;
-      }
-
-      if (shouldExtractGear && mockGearData && onGearExtracted) {
-        if (Array.isArray(mockGearData)) {
-          mockGearData.forEach((gear) => onGearExtracted(gear));
-        } else {
-          onGearExtracted(mockGearData);
-        }
-      }
-
-      setAddMessages((prev) => [
-        ...prev,
-        { id: (Date.now() + 1).toString(), role: 'assistant', content: assistantResponse, timestamp: new Date() },
-      ]);
-    } catch (error) {
-      const msg = error instanceof APIError
-        ? `System error: ${error.message}${error.status ? ` (HTTP ${error.status})` : ''}`
-        : `Error: ${error instanceof Error ? error.message : 'unknown'}`;
-      setAddMessages((prev) => [
-        ...prev,
-        { id: (Date.now() + 1).toString(), role: 'assistant', content: msg, timestamp: new Date() },
-      ]);
+      const list = await advisorListSessions(20);
+      setHistorySessions(list);
     } finally {
-      setAddIsLoading(false);
+      setHistoryLoading(false);
+    }
+  }, [advisorListSessions]);
+
+  // 履歴ドロップダウンを開いたら一覧をフェッチ
+  useEffect(() => {
+    if (historyOpen) void refreshHistory();
+  }, [historyOpen, refreshHistory]);
+
+  // サイドバーが閉じたらモードをリセット
+  useEffect(() => {
+    if (!isOpen) {
+      setPlusMenuOpen(false);
+      setHistoryOpen(false);
+      setInputMode('chat');
+      setImportText('');
+      setCompareSelection(new Set());
+    }
+  }, [isOpen]);
+
+  const gearItemsForCompare = advisorContext?.items ?? [];
+  const itemsById = useMemo(() => {
+    const map = new Map(gearItemsForCompare.map((item) => [item.id, item]));
+    return map;
+  }, [gearItemsForCompare]);
+
+  // FloatingChatInput からの初回プロンプトを Advisor に自動送信。
+  // nonce で同じテキストの再送も別イベント扱いし、同一 nonce は二重送信しない。
+  const lastConsumedNonceRef = useRef<number | null>(null);
+  const advisorReady = !!advisorContext && !!onApplyEdit;
+  useEffect(() => {
+    if (!isOpen || !initialAdvisorPrompt || !advisorReady) return;
+    if (lastConsumedNonceRef.current === initialAdvisorPrompt.nonce) return;
+    lastConsumedNonceRef.current = initialAdvisorPrompt.nonce;
+    void advisor.sendText(initialAdvisorPrompt.text);
+    onAdvisorPromptConsumed?.();
+  }, [isOpen, initialAdvisorPrompt, advisorReady, advisor, onAdvisorPromptConsumed]);
+
+  // ==================== Import 送信 ====================
+
+  const runImport = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed || importBusy) return;
+    setImportBusy(true);
+    const promptType = classifyImportPrompt(trimmed);
+    try {
+      if (promptType === 'url') {
+        const data = await extractFromUrl(trimmed, categories);
+        const matchedCategory = categories.find((cat) => cat.name === data.suggestedCategory);
+        onGearExtracted?.({
+          name: data.name, brand: data.brand, productUrl: trimmed,
+          categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
+          weightGrams: data.weightGrams, priceCents: data.priceCents,
+          season: '', priority: 3,
+        });
+        onNotify?.('success', `Imported: ${data.name}`);
+      } else if (promptType === 'url_with_prompt') {
+        const urlMatch = trimmed.match(/(https?:\/\/[^\s]+)/);
+        if (!urlMatch) {
+          onNotify?.('error', 'URL not detected');
+          return;
+        }
+        const url = urlMatch[1];
+        const urlData = await extractFromUrl(url, categories);
+        const enhanced = await enhanceUrlDataWithPrompt(urlData, trimmed);
+        const matchedCategory = categories.find((cat) => cat.name === enhanced.suggestedCategory);
+        onGearExtracted?.({
+          name: enhanced.name, brand: enhanced.brand, productUrl: url,
+          categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
+          weightGrams: enhanced.weightGrams, priceCents: enhanced.priceCents,
+          season: '', priority: 3,
+        });
+        onNotify?.('success', `Imported: ${enhanced.name}`);
+      } else if (promptType === 'multiple_urls') {
+        const urls = extractMultipleUrls(trimmed);
+        const results = await Promise.allSettled(urls.map((u) => extractFromUrl(u, categories)));
+        let okCount = 0;
+        results.forEach((r, idx) => {
+          if (r.status !== 'fulfilled') return;
+          const data = r.value;
+          const isFallback = data.source === 'fallback' ||
+            !data.name || data.name.includes('Failed') || data.name.includes('Product from');
+          if (isFallback) return;
+          const matchedCategory = categories.find((cat) => cat.name === data.suggestedCategory);
+          onGearExtracted?.({
+            name: data.name, brand: data.brand, productUrl: urls[idx],
+            imageUrl: data.imageUrl, categoryId: matchedCategory?.id,
+            requiredQuantity: 1, ownedQuantity: 0,
+            weightGrams: data.weightGrams, priceCents: data.priceCents,
+            season: '', priority: 3,
+          });
+          okCount += 1;
+        });
+        if (okCount > 0) onNotify?.('success', `Imported ${okCount} item${okCount > 1 ? 's' : ''}`);
+        if (okCount < urls.length) onNotify?.('error', `${urls.length - okCount} of ${urls.length} URLs could not be parsed`);
+      } else if (promptType === 'add_gear') {
+        const data = await extractFromPrompt(trimmed, categories);
+        const matchedCategory = categories.find((cat) => cat.name === data.suggestedCategory);
+        onGearExtracted?.({
+          name: data.name, brand: data.brand, productUrl: '',
+          categoryId: matchedCategory?.id, requiredQuantity: 1, ownedQuantity: 0,
+          weightGrams: data.weightGrams, priceCents: data.priceCents,
+          season: '', priority: 3,
+        });
+        onNotify?.('success', `Imported: ${data.name}`);
+      } else {
+        onNotify?.('error', 'Paste a product URL or type "Brand + Product name"');
+        return;
+      }
+      setImportText('');
+      setInputMode('chat');
+    } catch (err) {
+      const msg = err instanceof APIError
+        ? err.message
+        : err instanceof Error ? err.message : 'Import failed';
+      onNotify?.('error', `Import error: ${msg}`);
+    } finally {
+      setImportBusy(false);
     }
   };
 
-  const handleAddKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleAddSend();
-    }
+  // ==================== Compare 送信 ====================
+
+  const handleCompareSubmit = () => {
+    if (compareSelection.size < 2) return;
+    advisor.appendComparison([...compareSelection]);
+    setCompareSelection(new Set());
+    setInputMode('chat');
   };
 
-  // ==================== Advisor モード: ヘッダー情報 ====================
+  const toggleCompareSelect = (id: string) => {
+    setCompareSelection((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else if (next.size < 4) next.add(id);
+      return next;
+    });
+  };
+
+  const exitSubMode = () => {
+    setInputMode('chat');
+    setImportText('');
+    setCompareSelection(new Set());
+  };
+
+  // ==================== Header 情報 ====================
   const advisorHeaderInfo = useMemo(() => {
     if (!advisorContext) return null;
     const scope = advisorContext.packName
@@ -467,148 +409,216 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
     return `${scope}${base}${ul}`;
   }, [advisorContext, weightUnit]);
 
-  const advisorLastAssistantId = advisor.messages.filter((m) => m.role === 'assistant').at(-1)?.id;
+  // ==================== Input: キー操作 ====================
+  const handleChatKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (inputMode === 'import') void runImport(importText);
+      else advisor.handleSend();
+    }
+  };
+
+  const canCompare = gearItemsForCompare.length >= 2;
 
   // ==================== Render ====================
-  // Bottom sheet: 画面下部から transform translateY でスライドイン。
-  // backdrop は透過 + blur で、背景の chart / table が見えたまま操作できる。
+  // 右側スライドイン: デスクトップは 400px 固定、モバイルはフル幅 + backdrop。
+  // PacksPage 側で開放時に `paddingRight: 400px` のガターを確保して本体を縮める。
   return (
     <>
-      {isOpen && (
+      {isMobile && isOpen && (
         <div
-          className="fixed inset-0 z-[39] bg-black/30 backdrop-blur-sm transition-opacity duration-300"
+          className="fixed inset-0 z-[39] bg-black/30 transition-opacity duration-300"
           onClick={onClose}
           aria-hidden="true"
         />
       )}
       <aside
-        className="fixed left-0 right-0 bottom-0 z-40 flex flex-col
-                   bg-white dark:bg-gray-900
-                   border-t border-gray-200 dark:border-gray-700
-                   shadow-xl
+        className="fixed top-0 right-0 h-full z-40 flex flex-col
                    transition-transform duration-300 ease-in-out"
         style={{
-          height: isMobile ? '85vh' : 'min(70vh, 640px)',
-          transform: isOpen ? 'translateY(0)' : 'translateY(100%)',
-          borderTopLeftRadius: 'var(--radius-surface)',
-          borderTopRightRadius: 'var(--radius-surface)',
+          width: isMobile ? '100%' : '400px',
+          transform: isOpen ? 'translateX(0)' : 'translateX(100%)',
+          background: 'var(--surface-level-0)',
+          borderLeft: 'var(--border-default)',
+          boxShadow: 'var(--shadow-lg)',
         }}
         aria-label="Gear chat assistant"
       >
-        {/* Grabber bar (装飾): 下部シートであることを視覚的に示す */}
-        <div className="flex items-center justify-center pt-2 pb-1 shrink-0" aria-hidden="true">
-          <div className="h-1 w-10 rounded-full bg-gray-300 dark:bg-gray-600" />
-        </div>
-
-        {/* ヘッダー: mode tabs + close */}
-        <div className="flex items-center justify-between px-3 py-2 shrink-0
-                        bg-white dark:bg-gray-800
-                        border-b border-gray-200 dark:border-gray-700">
-          <div role="tablist" aria-label="Chat mode" className="inline-flex items-center gap-0.5 p-0.5 rounded-md bg-gray-100 dark:bg-gray-700">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mode === 'add'}
-              onClick={() => setMode('add')}
-              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
-                          ${mode === 'add'
-                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
-                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
-            >
-              Add
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={mode === 'advisor'}
-              disabled={!isAdvisorAvailable}
-              onClick={() => setMode('advisor')}
-              title={!isAdvisorAvailable ? 'Advisor requires gear context' : 'Optimization advisor'}
-              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
-                          disabled:opacity-40 disabled:cursor-not-allowed
-                          ${mode === 'advisor'
-                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
-                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
-            >
-              Advisor
-            </button>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close chat"
-            className="h-8 w-8 inline-flex items-center justify-center rounded-md
-                       text-gray-500 dark:text-gray-400
-                       hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        {/* ヘッダー */}
+        <div
+          className="flex items-center justify-between px-3 py-2 shrink-0"
+          style={{ background: 'var(--surface-level-0)', borderBottom: 'var(--border-divider)' }}
+        >
+          <div
+            className="inline-flex items-center h-control px-3 text-sm font-semibold"
+            style={{ color: 'var(--ink-primary)' }}
           >
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+            AI Chat
+          </div>
+          <div className="flex items-center gap-1">
+            {/* History ドロップダウン */}
+            <div className="relative" ref={historyRef}>
+              <button
+                type="button"
+                onClick={() => setHistoryOpen((v) => !v)}
+                aria-label="Chat history"
+                aria-expanded={historyOpen}
+                title="History"
+                className="icon-btn"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="9" />
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 7v5l3 2" />
+                </svg>
+              </button>
+              {historyOpen && (
+                <div
+                  role="menu"
+                  className="card absolute right-0 top-full mt-1 w-72 max-h-[60vh] overflow-y-auto z-20"
+                  style={{ borderRadius: 'var(--radius-control)', boxShadow: 'var(--shadow-lg)' }}
+                >
+                  {/* 新規チャット */}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => { advisor.startNewSession(); setHistoryOpen(false); }}
+                    className="w-full text-left px-3 py-2 text-xs flex items-center gap-2 transition-colors"
+                    style={{ color: 'var(--ink-primary)', borderBottom: 'var(--border-divider)' }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-level-1)'; }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                  >
+                    <span className="font-medium">+ New chat</span>
+                  </button>
+                  {historyLoading && (
+                    <div className="px-3 py-3 text-xs" style={{ color: 'var(--ink-muted)' }}>
+                      Loading…
+                    </div>
+                  )}
+                  {!historyLoading && historySessions.length === 0 && (
+                    <div className="px-3 py-3 text-xs" style={{ color: 'var(--ink-muted)' }}>
+                      No past sessions yet
+                    </div>
+                  )}
+                  {!historyLoading && historySessions.map((s) => {
+                    const active = advisor.currentSessionId === s.id;
+                    return (
+                      <div
+                        key={s.id}
+                        role="menuitem"
+                        className="group flex items-center gap-2 px-3 py-2 text-xs cursor-pointer transition-colors"
+                        style={{
+                          color: 'var(--ink-primary)',
+                          background: active ? 'var(--surface-level-1)' : 'transparent',
+                        }}
+                        onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = 'var(--surface-level-1)'; }}
+                        onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = active ? 'var(--surface-level-1)' : 'transparent'; }}
+                        onClick={() => { void advisor.loadSession(s.id); setHistoryOpen(false); }}
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="truncate font-medium">{s.title || 'Untitled'}</div>
+                          <div className="text-2xs" style={{ color: 'var(--ink-muted)' }}>
+                            {formatRelativeTime(s.updated_at)}
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          aria-label={`Delete ${s.title || 'session'}`}
+                          title="Delete"
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            await advisor.removeSession(s.id);
+                            await refreshHistory();
+                          }}
+                          className="opacity-0 group-hover:opacity-100 transition-opacity h-7 w-7 inline-flex items-center justify-center rounded-control shrink-0"
+                          style={{ color: 'var(--ink-muted)' }}
+                          onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-primary)'; }}
+                          onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-muted)'; }}
+                        >
+                          <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M9 7V4a1 1 0 011-1h4a1 1 0 011 1v3" />
+                          </svg>
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close chat"
+              className="icon-btn"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
 
-        {/* サブヘッダー: mode 別のコンテキスト情報 */}
-        {mode === 'advisor' && advisorHeaderInfo && (
-          <div className="px-4 py-2 shrink-0 text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-            {advisorHeaderInfo}
-          </div>
-        )}
-        {mode === 'add' && (
-          <div className="px-4 py-2 shrink-0 text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
-            {existingItemCount > 0 ? `${existingItemCount} items in your list` : 'Add gear by URL or name'}
-          </div>
-        )}
+        {/* サブヘッダー */}
+        <div
+          className="px-4 py-2 shrink-0 text-xs"
+          style={{ color: 'var(--ink-muted)', borderBottom: 'var(--border-divider)' }}
+        >
+          {advisorHeaderInfo ?? (existingItemCount > 0
+            ? `${existingItemCount} items in your list`
+            : 'No gear yet — add with + → Import')}
+        </div>
 
         {/* メッセージ一覧 */}
-        {mode === 'add' ? (
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
-            {addMessages.map((message) => (
-              <div
-                key={message.id}
-                className={`flex items-end ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
-              >
-                <div className={`max-w-[92%] p-3 text-xs leading-relaxed shadow-sm whitespace-pre-wrap
-                                 ${message.role === 'user'
-                                   ? 'rounded-lg rounded-br-sm bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900'
-                                   : 'rounded-lg rounded-bl-sm bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-gray-700'}`}>
-                  <div>{message.content}</div>
-                  <div className={`text-2xs mt-1 opacity-50 select-none ${message.role === 'user' ? 'text-right' : ''}`}>
-                    {TIME_FMT.format(message.timestamp)}
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {advisor.messages.map((message) => {
+            // 比較パネルメッセージ
+            if (message.comparison) {
+              const items = message.comparison.itemIds
+                .map((id) => itemsById.get(id))
+                .filter((x): x is NonNullable<typeof x> => !!x);
+              if (items.length < 2) return null;
+              return (
+                <div key={message.id} className="flex justify-start">
+                  <div className="max-w-[92%] w-full">
+                    <CompactComparisonPanel
+                      items={items}
+                      weightUnit={weightUnit}
+                      onFocusGear={onFocusGear}
+                    />
                   </div>
                 </div>
-              </div>
-            ))}
-            {addIsLoading && (
-              <div className="flex items-end justify-start">
-                <div className="p-3 rounded-lg rounded-bl-sm flex items-center gap-2
-                                bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 shadow-sm">
-                  <div className="w-3.5 h-3.5 rounded-full border-2 border-gray-400 dark:border-gray-500 border-t-transparent animate-spin" />
-                  <span className="text-xs text-gray-500 dark:text-gray-400">Analyzing…</span>
-                </div>
-              </div>
-            )}
-            <div ref={addMessagesEndRef} />
-          </div>
-        ) : (
-          <div className="flex-1 overflow-y-auto p-4 space-y-3">
-            {advisor.messages.map((message) => (
+              );
+            }
+
+            const isUser = message.role === 'user';
+            return (
               <div
                 key={message.id}
-                className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
               >
                 <div className="max-w-[92%]">
-                  <div className={`p-3 text-xs leading-relaxed shadow-sm
-                                   ${message.role === 'user'
-                                     ? 'rounded-lg rounded-br-sm bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900'
-                                     : 'rounded-lg rounded-bl-sm bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-gray-700'}`}>
+                  <div
+                    className={`has-noise p-3 text-xs leading-relaxed rounded-control ${isUser ? 'rounded-br-sm' : 'rounded-bl-sm'}`}
+                    data-noise={isUser ? 'control' : undefined}
+                    style={isUser
+                      ? { background: 'var(--mondrian-black)', color: 'var(--ink-inverse)' }
+                      : { background: 'var(--surface-level-1)', color: 'var(--ink-primary)', border: 'var(--border-divider)' }
+                    }
+                  >
                     <div className="whitespace-pre-wrap">
                       {message.content}
                       {advisor.isStreaming && message.id === advisorLastAssistantId && (
-                        <span className="inline-block w-0.5 h-3.5 ml-0.5 bg-gray-500 dark:bg-gray-400 animate-pulse align-text-bottom" />
+                        <span
+                          className="inline-block w-0.5 h-3.5 ml-0.5 animate-pulse align-text-bottom"
+                          style={{ background: 'currentColor' }}
+                        />
                       )}
                     </div>
                     {message.content && (
-                      <div className={`text-2xs mt-1 opacity-50 select-none ${message.role === 'user' ? 'text-right' : ''}`}>
+                      <div
+                        className={`text-2xs mt-1 select-none ${isUser ? 'text-right' : ''}`}
+                        style={{ color: isUser ? 'var(--ink-inverse)' : 'var(--ink-muted)', opacity: isUser ? 0.6 : 1 }}
+                      >
                         {TIME_FMT.format(message.timestamp)}
                       </div>
                     )}
@@ -639,113 +649,224 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
                   )}
                 </div>
               </div>
-            ))}
-            {advisor.isLoading && !advisor.isStreaming && (
-              <div className="flex justify-start">
-                <div className="p-3 rounded-lg rounded-bl-sm flex items-center gap-2
-                                bg-gray-50 dark:bg-gray-800 border border-gray-100 dark:border-gray-700 shadow-sm">
-                  <div className="w-3.5 h-3.5 rounded-full border-2 border-gray-400 dark:border-gray-500 border-t-transparent animate-spin" />
-                  <span className="text-xs text-gray-500 dark:text-gray-400">Analyzing…</span>
-                </div>
+            );
+          })}
+          {advisor.isLoading && !advisor.isStreaming && (
+            <div className="flex justify-start">
+              <div
+                className="has-noise p-3 rounded-control rounded-bl-sm flex items-center gap-2"
+                style={{ background: 'var(--surface-level-1)', border: 'var(--border-divider)' }}
+              >
+                <div
+                  className="w-3.5 h-3.5 rounded-full border-2 border-t-transparent animate-spin"
+                  style={{ borderColor: 'var(--ink-muted)', borderTopColor: 'transparent' }}
+                />
+                <span className="text-xs" style={{ color: 'var(--ink-muted)' }}>Analyzing…</span>
               </div>
-            )}
-            <div ref={advisorMessagesEndRef} />
-          </div>
-        )}
+            </div>
+          )}
+          <div ref={messagesEndRef} />
+        </div>
 
         {/* 入力エリア */}
-        <div className="shrink-0 px-4 py-3
-                        bg-white dark:bg-gray-800
-                        border-t border-gray-200 dark:border-gray-700">
-          {mode === 'add' ? (
-            <>
-              <div className="flex items-end gap-2">
-                <textarea
-                  ref={addInputRef}
-                  value={addInput}
-                  onChange={(e) => setAddInput(e.target.value)}
-                  onKeyDown={handleAddKeyDown}
-                  placeholder="Paste URL or describe gear… (Shift+Enter for new line)"
-                  disabled={addIsLoading}
-                  rows={2}
-                  className="flex-1 px-3 py-2 text-xs rounded-lg resize-none
-                             bg-white dark:bg-gray-900
-                             text-gray-800 dark:text-gray-100
-                             border border-gray-200 dark:border-gray-600
-                             focus:outline-none focus:ring-2 focus:ring-gray-400
-                             disabled:opacity-50"
-                />
+        <div
+          className="shrink-0 px-4 py-3"
+          style={{ background: 'var(--surface-level-0)', borderTop: 'var(--border-divider)' }}
+        >
+          {/* Compare picker overlay */}
+          {inputMode === 'compare' && (
+            <div className="card mb-2 overflow-hidden">
+              <div
+                className="flex items-center justify-between px-3 h-control text-xs"
+                style={{ borderBottom: 'var(--border-divider)' }}
+              >
+                <span className="font-medium" style={{ color: 'var(--ink-primary)' }}>
+                  Select items to compare ({compareSelection.size}/4)
+                </span>
                 <button
                   type="button"
-                  onClick={handleAddSend}
-                  disabled={!addInput.trim() || addIsLoading}
-                  className="h-9 px-4 rounded-lg text-xs font-medium
-                             bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900
-                             hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed
-                             transition-opacity"
+                  onClick={exitSubMode}
+                  className="transition-colors"
+                  style={{ color: 'var(--ink-muted)' }}
+                  onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-primary)'; }}
+                  onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-muted)'; }}
                 >
-                  Send
+                  Cancel
                 </button>
               </div>
-            </>
-          ) : (
-            <>
-              {/* Advisor クイックプロンプト */}
-              <div className="flex gap-1.5 mb-2 overflow-x-auto pb-1 scrollbar-thin">
-                {QUICK_PROMPTS.map((qp) => (
-                  <button
-                    key={qp.label}
-                    type="button"
-                    disabled={advisor.isLoading}
-                    onClick={() => advisor.sendText(qp.prompt)}
-                    className="inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium
-                               whitespace-nowrap shrink-0
-                               bg-white dark:bg-gray-700
-                               text-gray-700 dark:text-gray-200
-                               border border-gray-200 dark:border-gray-600
-                               hover:bg-gray-100 dark:hover:bg-gray-600 hover:border-gray-300 dark:hover:border-gray-500
-                               disabled:opacity-40 disabled:cursor-not-allowed
-                               transition-all"
-                  >
-                    <span>{qp.icon}</span>
-                    <span>{qp.label}</span>
-                  </button>
-                ))}
+              <div className="max-h-48 overflow-y-auto">
+                {gearItemsForCompare.length === 0 && (
+                  <div className="px-3 py-3 text-xs" style={{ color: 'var(--ink-muted)' }}>
+                    No items to compare.
+                  </div>
+                )}
+                {gearItemsForCompare.map((item) => {
+                  const checked = compareSelection.has(item.id);
+                  const atLimit = compareSelection.size >= 4 && !checked;
+                  return (
+                    <label
+                      key={item.id}
+                      className={`flex items-center gap-2 px-3 py-1.5 text-xs cursor-pointer transition-colors
+                                  ${atLimit ? 'opacity-40 cursor-not-allowed' : ''}`}
+                      style={atLimit ? undefined : { color: 'var(--ink-primary)' }}
+                      onMouseEnter={atLimit ? undefined : (e) => { (e.currentTarget as HTMLLabelElement).style.background = 'var(--surface-level-1)'; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLLabelElement).style.background = 'transparent'; }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={atLimit}
+                        onChange={() => toggleCompareSelect(item.id)}
+                        className="h-3.5 w-3.5 rounded-control"
+                        style={{ accentColor: 'var(--mondrian-black)' }}
+                      />
+                      <span className="flex-1 truncate">{item.name}</span>
+                      <span className="shrink-0 tabular-nums" style={{ color: 'var(--ink-muted)' }}>
+                        {typeof item.weightGrams === 'number' ? formatWeight(item.weightGrams, weightUnit) : '—'}
+                      </span>
+                    </label>
+                  );
+                })}
               </div>
-              <div className="flex items-end gap-2">
-                <textarea
-                  ref={advisorInputRef}
-                  value={advisor.input}
-                  onChange={(e) => advisor.setInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      advisor.handleSend();
-                    }
-                  }}
-                  placeholder="Ask about your gear… (Shift+Enter for new line)"
+              <div
+                className="px-3 py-2 flex justify-end"
+                style={{ borderTop: 'var(--border-divider)' }}
+              >
+                <button
+                  type="button"
+                  disabled={compareSelection.size < 2}
+                  onClick={handleCompareSubmit}
+                  className="btn-primary btn-xs disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  Compare ({compareSelection.size})
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Import mode header */}
+          {inputMode === 'import' && (
+            <div className="mb-2 flex items-center justify-between text-xs" style={{ color: 'var(--ink-secondary)' }}>
+              <span className="font-medium">Import gear — paste URL or describe</span>
+              <button
+                type="button"
+                onClick={exitSubMode}
+                style={{ color: 'var(--ink-muted)' }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-primary)'; }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.color = 'var(--ink-muted)'; }}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+
+          {/* Quick prompts (chat mode only) */}
+          {inputMode === 'chat' && (
+            <div className="flex gap-1.5 mb-2 overflow-x-auto pb-1 scrollbar-thin">
+              {QUICK_PROMPTS.map((qp) => (
+                <button
+                  key={qp.label}
+                  type="button"
                   disabled={advisor.isLoading}
-                  rows={2}
-                  className="flex-1 px-3 py-2 text-xs rounded-lg resize-none
-                             bg-white dark:bg-gray-900
-                             text-gray-800 dark:text-gray-100
-                             border border-gray-200 dark:border-gray-600
-                             focus:outline-none focus:ring-2 focus:ring-gray-400
-                             disabled:opacity-50"
-                />
+                  onClick={() => advisor.sendText(qp.prompt)}
+                  className="glass-header-chip h-control px-3 gap-1.5 text-xs font-medium whitespace-nowrap shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+                  style={{ color: 'var(--ink-secondary)' }}
+                >
+                  <span>{qp.icon}</span>
+                  <span>{qp.label}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Input row — compare mode では入力欄を隠す */}
+          {inputMode !== 'compare' && (
+            <div className="flex items-end gap-2">
+              {/* + ボタン + ポップオーバー */}
+              <div className="relative" ref={plusMenuRef}>
                 <button
                   type="button"
-                  onClick={advisor.handleSend}
-                  disabled={!advisor.input.trim() || advisor.isLoading}
-                  className="h-9 px-4 rounded-lg text-xs font-medium
-                             bg-gray-800 dark:bg-gray-200 text-white dark:text-gray-900
-                             hover:opacity-80 disabled:opacity-40 disabled:cursor-not-allowed
-                             transition-opacity"
+                  onClick={() => setPlusMenuOpen((v) => !v)}
+                  aria-label="Open attach menu"
+                  aria-expanded={plusMenuOpen}
+                  disabled={importBusy || advisor.isLoading}
+                  className="icon-btn disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  Send
+                  <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+                  </svg>
                 </button>
+                {plusMenuOpen && (
+                  <div
+                    role="menu"
+                    className="card absolute bottom-full left-0 mb-1 w-44 overflow-hidden z-10"
+                    style={{ borderRadius: 'var(--radius-control)', boxShadow: 'var(--shadow-md)' }}
+                  >
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => { setInputMode('import'); setPlusMenuOpen(false); }}
+                      className="w-full text-left px-3 py-2 text-xs flex items-center gap-2 transition-colors"
+                      style={{ color: 'var(--ink-primary)' }}
+                      onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-level-1)'; }}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                    >
+                      <span>🔗</span>
+                      <span>Import gear</span>
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      disabled={!canCompare}
+                      onClick={() => { setInputMode('compare'); setPlusMenuOpen(false); }}
+                      title={canCompare ? 'Compare gear items' : 'Need at least 2 items to compare'}
+                      className="w-full text-left px-3 py-2 text-xs flex items-center gap-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                      style={{ color: 'var(--ink-primary)' }}
+                      onMouseEnter={canCompare ? (e) => { (e.currentTarget as HTMLButtonElement).style.background = 'var(--surface-level-1)'; } : undefined}
+                      onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                    >
+                      <span>⚖</span>
+                      <span>Compare</span>
+                    </button>
+                  </div>
+                )}
               </div>
-            </>
+
+              <textarea
+                ref={inputRef}
+                value={inputMode === 'import' ? importText : advisor.input}
+                onChange={(e) => (
+                  inputMode === 'import'
+                    ? setImportText(e.target.value)
+                    : advisor.setInput(e.target.value)
+                )}
+                onKeyDown={handleChatKeyDown}
+                placeholder={inputMode === 'import'
+                  ? 'Paste URL or describe gear (Enter to import)'
+                  : 'Ask about your gear… (Shift+Enter for new line)'}
+                disabled={importBusy || advisor.isLoading}
+                rows={2}
+                className="flex-1 px-3 py-2 text-xs rounded-control resize-none focus:outline-none disabled:opacity-50"
+                style={{
+                  background: 'var(--surface-level-0)',
+                  color: 'var(--ink-primary)',
+                  border: '1px solid var(--stroke-subtle)',
+                }}
+              />
+
+              <button
+                type="button"
+                onClick={() => (inputMode === 'import' ? runImport(importText) : advisor.handleSend())}
+                disabled={
+                  inputMode === 'import'
+                    ? (!importText.trim() || importBusy)
+                    : (!advisor.input.trim() || advisor.isLoading)
+                }
+                className="btn-primary h-control px-4 text-xs disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {inputMode === 'import' ? (importBusy ? 'Importing…' : 'Import') : 'Send'}
+              </button>
+            </div>
           )}
         </div>
       </aside>

--- a/client/components/CompactComparisonPanel.tsx
+++ b/client/components/CompactComparisonPanel.tsx
@@ -1,0 +1,96 @@
+import React, { useMemo } from 'react';
+import type { GearItemWithCalculated } from '../utils/types';
+import { formatWeight } from '../utils/weightUnit';
+import { formatPrice } from '../utils/formatters';
+
+/**
+ * ChatSidebar 内に差し込まれる 2〜4 件のギア比較パネル。
+ * 幅 400px のサイドバーを想定した縦型。最軽量・最安値セルを微強調。
+ */
+interface Props {
+  items: GearItemWithCalculated[];
+  weightUnit: 'g' | 'oz';
+  onFocusGear?: (gearId: string) => void;
+}
+
+const CompactComparisonPanel: React.FC<Props> = ({ items, weightUnit, onFocusGear }) => {
+  const { minWeight, minPrice } = useMemo(() => {
+    const weights = items
+      .map((i) => i.weightGrams)
+      .filter((w): w is number => typeof w === 'number' && w > 0);
+    const prices = items
+      .map((i) => i.priceCents)
+      .filter((p): p is number => typeof p === 'number' && p > 0);
+    return {
+      minWeight: weights.length ? Math.min(...weights) : null,
+      minPrice: prices.length ? Math.min(...prices) : null,
+    };
+  }, [items]);
+
+  if (items.length < 2) return null;
+
+  return (
+    <div className="card mt-2 overflow-hidden">
+      <div
+        className="px-3 py-1.5 text-2xs uppercase tracking-wide"
+        style={{
+          background: 'var(--surface-level-1)',
+          color: 'var(--ink-muted)',
+          borderBottom: 'var(--border-divider)',
+        }}
+      >
+        Comparison ({items.length})
+      </div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr style={{ color: 'var(--ink-muted)' }}>
+            <th className="text-left font-medium px-3 py-1.5">Item</th>
+            <th className="text-right font-medium px-2 py-1.5 w-16">Weight</th>
+            <th className="text-right font-medium px-3 py-1.5 w-20">Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, idx) => {
+            const isLightest =
+              minWeight !== null && item.weightGrams === minWeight;
+            const isCheapest =
+              minPrice !== null && item.priceCents === minPrice;
+            const clickable = !!onFocusGear;
+            return (
+              <tr
+                key={item.id}
+                className={clickable ? 'cursor-pointer transition-colors' : ''}
+                style={{ borderTop: idx === 0 ? undefined : 'var(--border-divider)' }}
+                onClick={clickable ? () => onFocusGear!(item.id) : undefined}
+                onMouseEnter={clickable ? (e) => { (e.currentTarget as HTMLTableRowElement).style.background = 'var(--surface-level-1)'; } : undefined}
+                onMouseLeave={clickable ? (e) => { (e.currentTarget as HTMLTableRowElement).style.background = 'transparent'; } : undefined}
+              >
+                <td className="px-3 py-1.5 truncate max-w-[180px]" style={{ color: 'var(--ink-primary)' }}>
+                  {item.name}
+                </td>
+                <td
+                  className={`px-2 py-1.5 text-right tabular-nums ${isLightest ? 'font-semibold' : ''}`}
+                  style={{ color: isLightest ? 'var(--ink-primary)' : 'var(--ink-secondary)' }}
+                >
+                  {typeof item.weightGrams === 'number'
+                    ? formatWeight(item.weightGrams, weightUnit)
+                    : '—'}
+                </td>
+                <td
+                  className={`px-3 py-1.5 text-right tabular-nums ${isCheapest ? 'font-semibold' : ''}`}
+                  style={{ color: isCheapest ? 'var(--ink-primary)' : 'var(--ink-secondary)' }}
+                >
+                  {typeof item.priceCents === 'number'
+                    ? formatPrice(item.priceCents)
+                    : '—'}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default CompactComparisonPanel;

--- a/client/components/CompactSummary.tsx
+++ b/client/components/CompactSummary.tsx
@@ -41,7 +41,7 @@ const CompactSummary: React.FC<CompactSummaryProps> = ({ totals, viewMode = 'wei
   return (
     <Card hover className="p-2">
       <div className="mb-2">
-        <h3 className="text-xs font-semibold text-gray-900">
+        <h3 className="text-xs font-semibold" style={{ color: 'var(--ink-primary)' }}>
           Pack Summary
         </h3>
       </div>
@@ -49,17 +49,17 @@ const CompactSummary: React.FC<CompactSummaryProps> = ({ totals, viewMode = 'wei
         {stats.map((stat, index) => {
           const isSelected = stat.mode && viewMode === stat.mode;
           const isClickable = stat.mode !== null && onViewModeChange;
-          
+
           return (
             <div
               key={index}
-              className={`flex flex-col items-center justify-center group transition-all duration-200 p-2 rounded-lg border-2 ${
+              className={`flex flex-col items-center justify-center group transition-all duration-200 p-2 rounded-control border ${
                 isClickable ? 'cursor-pointer hover:scale-105' : ''
-              } ${
-                isSelected 
-                  ? 'bg-gray-200 border-gray-600' 
-                  : 'bg-gray-50 border-transparent'
               }`}
+              style={{
+                background: isSelected ? 'var(--surface-level-2)' : 'var(--surface-level-1)',
+                borderColor: isSelected ? 'var(--stroke-strong)' : 'transparent',
+              }}
               onClick={() => {
                 if (stat.mode && onViewModeChange) {
                   onViewModeChange(stat.mode);
@@ -68,20 +68,26 @@ const CompactSummary: React.FC<CompactSummaryProps> = ({ totals, viewMode = 'wei
             >
               <div className="flex items-center space-x-1 mb-0.5">
                 <span
-                  className={`text-2xs font-bold w-4 h-4 flex items-center justify-center rounded shadow-sm transition-all duration-200 text-white bg-gray-600 ${
+                  className={`text-2xs font-bold w-4 h-4 flex items-center justify-center rounded-control transition-all duration-200 ${
                     isClickable ? 'group-hover:scale-110' : ''
                   }`}
+                  style={{
+                    background: 'var(--mondrian-black)',
+                    color: 'var(--ink-inverse)',
+                    boxShadow: 'var(--shadow-sm)',
+                  }}
                 >
                   {stat.icon}
                 </span>
-                <span className="text-2xs font-medium text-gray-500">
+                <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
                   {stat.label}
                 </span>
               </div>
               <div
-                className={`text-sm font-bold transition-all duration-200 text-gray-700 ${
+                className={`text-sm font-bold transition-all duration-200 ${
                   isClickable ? 'group-hover:scale-110' : ''
                 }`}
+                style={{ color: 'var(--ink-secondary)' }}
               >
                 {stat.value}
               </div>

--- a/client/components/FloatingChatInput.tsx
+++ b/client/components/FloatingChatInput.tsx
@@ -1,0 +1,98 @@
+import React, { useRef, useState } from 'react';
+
+/**
+ * FloatingChatInput — 画面下にガラス透明で常駐する Advisor 入力欄。
+ *
+ * デスクトップは下中央にピル、モバイルは下端横長で表示。
+ * 既定は半透明 + 弱い shadow。フォーカス / ホバー / 文字入力で背景が濃くなり、
+ * Send ボタンは入力空 & 未ホバー時は半透明（"関連 UI もホバー" の Minimal 化）。
+ *
+ * Enter 送信で `onSubmit(text)` が呼ばれる前提（親が ChatSidebar を Advisor で開く）。
+ * `chatOpen=true` の間は非表示（サイドバーと入力欄の二重表示を避ける）。
+ */
+interface Props {
+  onSubmit: (text: string) => void;
+  chatOpen: boolean;
+}
+
+const FloatingChatInput: React.FC<Props> = ({ onSubmit, chatOpen }) => {
+  const [value, setValue] = useState('');
+  const [focused, setFocused] = useState(false);
+  const [hovered, setHovered] = useState(false);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  if (chatOpen) return null;
+
+  const submit = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setValue('');
+    inputRef.current?.blur();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    } else if (e.key === 'Escape') {
+      inputRef.current?.blur();
+    }
+  };
+
+  // active = フォーカス or ホバー or 入力済み → ガラスを濃くする
+  const hasText = value.trim().length > 0;
+  const active = focused || hovered || hasText;
+
+  return (
+    <div
+      className="fixed z-30 bottom-3 left-1/2 -translate-x-1/2 w-[min(560px,calc(100vw-1.5rem))]"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className="flex items-end gap-2 px-3 py-2 rounded-control transition-all duration-200"
+        style={{
+          background: active
+            ? 'color-mix(in srgb, var(--surface-level-0) 95%, transparent)'
+            : 'color-mix(in srgb, var(--surface-level-0) 60%, transparent)',
+          backdropFilter: 'blur(12px) saturate(140%)',
+          WebkitBackdropFilter: 'blur(12px) saturate(140%)',
+          border: '1px solid var(--stroke-subtle)',
+          boxShadow: active ? 'var(--shadow-lg)' : 'var(--shadow-sm)',
+        }}
+      >
+        <textarea
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask the AI advisor…"
+          rows={1}
+          className="flex-1 resize-none bg-transparent px-2 py-2 text-sm focus:outline-none max-h-32"
+          style={{ color: 'var(--ink-primary)' }}
+        />
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!hasText}
+          aria-label="Send to AI advisor"
+          className="h-control w-control inline-flex items-center justify-center rounded-control transition-all duration-200"
+          style={{
+            background: hasText ? 'var(--mondrian-black)' : 'transparent',
+            color: hasText ? 'var(--ink-inverse)' : 'var(--ink-muted)',
+            opacity: active || hasText ? 1 : 0.4,
+          }}
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FloatingChatInput;

--- a/client/components/GearTable/TableRow.tsx
+++ b/client/components/GearTable/TableRow.tsx
@@ -73,33 +73,48 @@ const TableRow: React.FC<TableRowProps> = ({
     if (item.ownedQuantity < 0 || item.requiredQuantity < 1) {
       return <span className="gear-anomaly-value" title="Invalid quantity">!</span>
     }
+    const sep = <span className="mx-0.5" style={{ color: 'var(--ink-disabled)' }}>/</span>
+    const sub = (n: number) => (
+      <span style={{ color: 'var(--ink-muted)' }}>{n}</span>
+    )
     switch (quantityDisplayMode) {
       case 'owned':
         return (
           <span className="gear-text-num">
             <span className="font-semibold">{item.ownedQuantity}</span>
-            <span className="text-gray-400 dark:text-gray-500 mx-0.5">/</span>
-            <span className="text-gray-500 dark:text-gray-300">{item.requiredQuantity}</span>
+            {sep}
+            {sub(item.requiredQuantity)}
           </span>
         )
       case 'need':
         return (
           <span className="gear-text-num">
-            <span className="text-gray-500 dark:text-gray-300">{item.ownedQuantity}</span>
-            <span className="text-gray-400 dark:text-gray-500 mx-0.5">/</span>
+            {sub(item.ownedQuantity)}
+            {sep}
             <span className="font-semibold">{item.requiredQuantity}</span>
           </span>
         )
       default:
         return (
           <span className="gear-text-num">
-            <span className="text-gray-500 dark:text-gray-300">{item.ownedQuantity}</span>
-            <span className="text-gray-400 dark:text-gray-500 mx-0.5">/</span>
+            {sub(item.ownedQuantity)}
+            {sep}
             <span className="font-semibold">{item.requiredQuantity}</span>
           </span>
         )
     }
   }
+
+  // 行の背景: 選択 / pack内 / hover の優先順位を CSS 変数で表現。
+  // Mondrian Blue 系 (pack 内ハイライト) は Tailwind blue-50/blue-900 の代わりに
+  // --mondrian-blue を低 opacity で使う。
+  const rowBackground = (() => {
+    if (isHighlighted && !isSelected) return undefined; // inline style で warningTone を使う
+    if (isSelected) return 'var(--surface-level-2)';
+    if (activePackName && isInActivePack) return 'color-mix(in srgb, var(--mondrian-blue) 12%, transparent)';
+    if (isHovered) return 'var(--surface-level-1)';
+    return undefined;
+  })();
 
   return (
     <tr
@@ -107,22 +122,16 @@ const TableRow: React.FC<TableRowProps> = ({
       onClick={onItemSelect ? () => onItemSelect(item.id) : undefined}
       onMouseEnter={onItemHover ? () => onItemHover(item.id) : undefined}
       onMouseLeave={onItemHover ? () => onItemHover(null) : undefined}
-      className={`gear-table-row transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-gray-700 ${
+      className={`gear-table-row transition-colors duration-150 hover:bg-[var(--surface-level-1)] ${
         onItemSelect ? 'cursor-pointer' : ''
-      } ${
-        isSelected
-          ? 'bg-gray-50 dark:bg-gray-700 ring-2 ring-gray-400 dark:ring-gray-500 ring-inset'
-          : activePackName && isInActivePack
-            ? 'bg-blue-50/55 dark:bg-blue-900/20'
-          : isHighlighted
-            ? 'border-l-2'
-          : isHovered
-            ? 'bg-gray-50 dark:bg-gray-700'
-            : 'bg-transparent'
-      }`}
-      style={isHighlighted && !isSelected
-        ? { backgroundColor: warningTone.background, borderLeftColor: warningTone.solid }
-        : undefined}
+      } ${isHighlighted ? 'border-l-2' : ''}`}
+      style={{
+        background: rowBackground,
+        ...(isSelected ? { boxShadow: 'inset 0 0 0 2px var(--stroke-strong)' } : {}),
+        ...(isHighlighted && !isSelected
+          ? { backgroundColor: warningTone.background, borderLeftColor: warningTone.solid }
+          : {}),
+      }}
     >
       {/* Pack Toggle: 編集中も常時表示 (pack 追加と行編集を独立させるため) */}
       {activePackName && onTogglePackItem && (
@@ -133,12 +142,8 @@ const TableRow: React.FC<TableRowProps> = ({
               e.stopPropagation()
               onTogglePackItem(item.id)
             }}
-            className={[
-              'p-0.5 rounded transition-colors',
-              isInActivePack
-                ? 'text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-200'
-                : 'text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-400'
-            ].join(' ')}
+            className="p-0.5 rounded-control transition-colors"
+            style={{ color: isInActivePack ? 'var(--mondrian-blue)' : 'var(--ink-disabled)' }}
             title={`${isInActivePack ? 'Remove from' : 'Add to'} ${activePackName}`}
           >
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill={isInActivePack ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={isInActivePack ? 0 : 1.5}>
@@ -205,7 +210,8 @@ const TableRow: React.FC<TableRowProps> = ({
                     href={item.productUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hover:underline transition-colors text-gray-800 dark:text-gray-100"
+                    className="hover:underline transition-colors"
+                    style={{ color: 'var(--ink-primary)' }}
                   >
                     {item.name}
                   </a>

--- a/client/components/InventoryWorkspace.tsx
+++ b/client/components/InventoryWorkspace.tsx
@@ -13,6 +13,7 @@ import PackInfoSection from './PackInfoSection';
 import NotificationPopup from './NotificationPopup';
 import SkeletonLoader from './ui/SkeletonLoader';
 import ChatSidebar from './ChatSidebar';
+import FloatingChatInput from './FloatingChatInput';
 
 // 旧 GearForm / CategoryManager / ChatPopup / UrlBulkImportModal / GearInputModal
 // および Login モーダルは ChatSidebar 一本化 & Landing 導入で廃止済み。
@@ -58,6 +59,9 @@ export default function InventoryWorkspace({
 }: InventoryWorkspaceProps) {
   const {
     showChat, setShowChat,
+    pendingAdvisorPrompt,
+    launchAdvisor,
+    consumePendingAdvisorPrompt,
     gearItems,
     categories,
     isLoading,
@@ -316,7 +320,7 @@ export default function InventoryWorkspace({
         )}
       </div>
 
-      {/* Chat 中心 UX: Add / Advisor 統合サイドバー */}
+      {/* Chat 中心 UX: 1 本化サイドバー（+ → Import gear / Compare）*/}
       <ChatSidebar
         isOpen={showChat}
         onClose={() => setShowChat(false)}
@@ -326,7 +330,17 @@ export default function InventoryWorkspace({
         onFocusGear={handleFocusGear}
         categories={categories}
         existingItemCount={gearItems.length}
+        onNotify={(type, msg) => {
+          if (type === 'success') showSuccess(msg);
+          else if (type === 'error') showError(msg);
+          else showSuccess(msg);
+        }}
+        initialAdvisorPrompt={pendingAdvisorPrompt}
+        onAdvisorPromptConsumed={consumePendingAdvisorPrompt}
       />
+
+      {/* 常時表示のガラスフローティング入力 — Chat の主入口 */}
+      <FloatingChatInput chatOpen={showChat} onSubmit={launchAdvisor} />
 
       <NotificationPopup
         messages={messages}

--- a/client/components/PacksPage.tsx
+++ b/client/components/PacksPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../utils/AuthContext';
 import { useAppState } from '../hooks/useAppState';
 import { usePacks } from '../hooks/usePacks';
 import { useProfile } from '../hooks/useProfile';
+import { useIsMobile } from '../hooks/useResponsiveSize';
 import InventoryWorkspace from './InventoryWorkspace';
 import ProfileHeader from './ProfileHeader';
 import SettingsModal from './SettingsModal';
@@ -15,7 +16,6 @@ interface PacksPageProps {
   isAuthenticated: boolean;
   userName?: string;
   onLogout: () => void;
-  onShowChat?: () => void;
 }
 
 export default function PacksPage({
@@ -23,12 +23,12 @@ export default function PacksPage({
   isAuthenticated,
   userName,
   onLogout,
-  onShowChat,
 }: PacksPageProps) {
   const { user } = useAuth();
-  const { gearItems } = appState;
+  const { gearItems, showChat } = appState;
   const { packs, createPack, updatePack, deletePack, toggleItemInPack, addItemsToPack } = usePacks(user?.id ?? fallbackUserId);
   const { profile, updateField, plan } = useProfile(user?.name);
+  const isMobile = useIsMobile();
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
@@ -67,19 +67,20 @@ export default function PacksPage({
     }
   };
 
-  // Chat は bottom sheet 化したため、右余白を確保する必要はなし。
-  // main content は常時フル幅。
+  // Chat が開いているデスクトップでは右余白 400px を確保し、
+  // サイドバーと本体が重ならないようにする。モバイルはフル幅オーバーレイ。
+  const chatSidebarGutter = showChat && !isMobile ? { paddingRight: '400px' } : undefined;
 
   return (
     <main
       id="inventory-overview"
-      className="max-w-6xl mx-auto min-h-screen px-1.5 pt-3 pb-4 sm:px-4 md:px-6 lg:px-4"
+      className="max-w-6xl mx-auto min-h-screen px-1.5 pt-3 pb-24 sm:px-4 md:px-6 lg:px-4 transition-[padding] duration-300 ease-in-out"
+      style={chatSidebarGutter}
     >
       <div className="flex min-h-0 flex-col gap-3">
         <ProfileHeader
           profile={profile}
           onOpenSettings={() => setSettingsOpen(true)}
-          onShowChat={onShowChat}
         />
 
         <div className="min-h-0 flex-1">

--- a/client/components/ProfileEditorModal.tsx
+++ b/client/components/ProfileEditorModal.tsx
@@ -1,56 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import type { ProfileSettings, UserPlan } from '../hooks/useProfile';
+import React, { useEffect } from 'react';
+import type { ProfileSettings } from '../hooks/useProfile';
 import { useImageUpload } from '../hooks/useImageUpload';
-import { createCheckoutSession, createPortalSession } from '../services/billingService';
+
+/**
+ * Profile 編集フォーム本体（モーダル chrome なし）。
+ *
+ * - 単独モーダルは廃止し、Settings モーダルの Profile タブから直接利用される。
+ * - Plan / 課金 UI は Settings モーダルの Plan タブに分離済みのため、ここでは扱わない。
+ * - 全ての色はデザイントークン (`--ink-*`, `--stroke-*`, `--surface-*`) に統一。
+ *   `dark:` プレフィックスのハードコードは使わない。
+ */
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <label className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{children}</label>
+  <label
+    className="text-xs uppercase tracking-wide"
+    style={{ color: 'var(--ink-muted)' }}
+  >
+    {children}
+  </label>
 );
-
-const PlanSection: React.FC<{ plan: UserPlan }> = ({ plan }) => {
-  const [loading, setLoading] = useState(false);
-
-  const goTo = async (getUrl: () => Promise<string>, errorMessage: string) => {
-    setLoading(true);
-    try {
-      window.location.href = await getUrl();
-    } catch (err) {
-      console.error('[Billing]', err);
-      alert(errorMessage);
-      setLoading(false);
-    }
-  };
-
-  return (
-    <div className="space-y-1.5">
-      <SectionLabel>Plan</SectionLabel>
-      <div className="flex items-center justify-between text-sm">
-        <span className="text-gray-700 dark:text-gray-300">
-          現在のプラン: <strong>{plan === 'pro' ? 'Pro' : 'Free'}</strong>
-        </span>
-        {plan === 'free' ? (
-          <button
-            type="button"
-            className="btn-primary"
-            onClick={() => goTo(createCheckoutSession, '決済ページを開けませんでした。時間をおいて再試行してください。')}
-            disabled={loading}
-          >
-            {loading ? '読込中...' : 'Upgrade to Pro'}
-          </button>
-        ) : (
-          <button
-            type="button"
-            className="btn-secondary"
-            onClick={() => goTo(createPortalSession, 'サブスクリプション管理ページを開けませんでした。')}
-            disabled={loading}
-          >
-            {loading ? '読込中...' : 'Manage'}
-          </button>
-        )}
-      </div>
-    </div>
-  );
-};
 
 /** ギア入力と同じドラッグ&ドロップ画像選択UI（コンパクト版） */
 const ImageDropZone: React.FC<{
@@ -60,7 +28,16 @@ const ImageDropZone: React.FC<{
   inputId: string;
   height?: string;
 }> = ({ imageUrl, onSelect, onRemove, inputId, height = 'max-h-24' }) => {
-  const { isDragging, imagePreview, handleDragOver, handleDragLeave, handleDrop, handleImageSelect, setPreview, removeImage } = useImageUpload();
+  const {
+    isDragging,
+    imagePreview,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handleImageSelect,
+    setPreview,
+    removeImage,
+  } = useImageUpload();
 
   useEffect(() => {
     setPreview(imageUrl || null);
@@ -73,25 +50,29 @@ const ImageDropZone: React.FC<{
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={(e) => handleDrop(e, onSelect)}
-      className={`border-2 border-dashed rounded-md p-2 text-center transition-colors ${
-        isDragging ? 'border-gray-700 bg-gray-50 dark:bg-gray-700' : 'border-gray-300 dark:border-gray-600'
-      }`}
+      className="border-2 border-dashed rounded-control p-2 text-center transition-colors"
+      style={{
+        borderColor: isDragging ? 'var(--ink-primary)' : 'var(--stroke-subtle)',
+        background: isDragging ? 'var(--surface-level-1)' : 'transparent',
+      }}
     >
       {preview ? (
         <div className="relative">
-          <img src={preview} alt="" className={`${height} w-full object-cover rounded`} />
+          <img src={preview} alt="" className={`${height} w-full object-cover rounded-control`} />
           <button
             type="button"
             onClick={() => removeImage(onRemove)}
-            className="absolute top-1 right-1 h-5 w-5 rounded-full bg-red-500 text-white text-2xs inline-flex items-center justify-center"
+            aria-label="Remove image"
+            className="absolute top-1 right-1 h-5 w-5 rounded-full text-2xs inline-flex items-center justify-center"
+            style={{ background: 'var(--mondrian-red)', color: 'var(--ink-inverse)' }}
           >
             ✕
           </button>
         </div>
       ) : (
         <div className="py-1">
-          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">
-            Drag & drop or click to select
+          <p className="text-xs mb-1" style={{ color: 'var(--ink-muted)' }}>
+            Drag &amp; drop or click to select
           </p>
           <input
             type="file"
@@ -102,7 +83,7 @@ const ImageDropZone: React.FC<{
           />
           <label
             htmlFor={inputId}
-            className="btn-secondary text-xs px-3 py-1 rounded cursor-pointer"
+            className="btn-secondary btn-xs cursor-pointer"
           >
             Choose Image
           </label>
@@ -112,20 +93,12 @@ const ImageDropZone: React.FC<{
   );
 };
 
-// ==================== Form (再利用可能な中身のみ) ====================
-
 interface ProfileEditorFormProps {
   profile: ProfileSettings;
   onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
-  plan?: UserPlan;
 }
 
-/**
- * プロフィール編集フォーム本体 (モーダル chrome なし)。
- * 単体モーダル (`ProfileEditorModal`) と統合 Settings (`SettingsModal`) の
- * 両方から再利用される。
- */
-export const ProfileEditorForm: React.FC<ProfileEditorFormProps> = ({ profile, onUpdate, plan = 'free' }) => (
+export const ProfileEditorForm: React.FC<ProfileEditorFormProps> = ({ profile, onUpdate }) => (
   <div className="space-y-3">
     <div className="space-y-1.5">
       <SectionLabel>Header</SectionLabel>
@@ -164,34 +137,5 @@ export const ProfileEditorForm: React.FC<ProfileEditorFormProps> = ({ profile, o
         onChange={(e) => onUpdate('bio', e.target.value)}
       />
     </div>
-    <PlanSection plan={plan} />
   </div>
 );
-
-// ==================== Modal wrapper (後方互換) ====================
-
-interface ProfileEditorModalProps {
-  profile: ProfileSettings;
-  onUpdate: <K extends keyof ProfileSettings>(key: K, value: ProfileSettings[K]) => void;
-  onClose: () => void;
-  plan?: UserPlan;
-}
-
-const ProfileEditorModal: React.FC<ProfileEditorModalProps> = ({ profile, onUpdate, onClose, plan = 'free' }) => (
-  <div className="modal-overlay" onClick={onClose}>
-    <div className="modal-panel-lg" onClick={(e) => e.stopPropagation()}>
-      <div className="px-4 py-3 border-b border-gray-200 flex justify-between items-center">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Edit Profile</h3>
-        <button type="button" className="text-gray-400 hover:text-gray-600" onClick={onClose}>✕</button>
-      </div>
-      <div className="px-4 py-3">
-        <ProfileEditorForm profile={profile} onUpdate={onUpdate} plan={plan} />
-        <div className="flex items-center justify-end pt-3">
-          <button type="button" className="btn-primary" onClick={onClose}>Done</button>
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-export default React.memo(ProfileEditorModal);

--- a/client/components/ProfileHeader.tsx
+++ b/client/components/ProfileHeader.tsx
@@ -4,20 +4,16 @@ import type { ProfileSettings } from '../hooks/useProfile';
 interface ProfileHeaderProps {
   profile: ProfileSettings;
   onOpenSettings: () => void;
-  onShowChat?: () => void;
 }
 
 /**
  * ProfileHeader — 画面上部のプロフィール表示 + 操作コントロール。
  *
- * アイコンは **Chat / Settings の 2 つ** に集約:
- * - Chat: bottom sheet 形式の ChatSidebar を開く
- * - Settings: tab モーダル (Profile / Account) を開く
- *
- * ダークモード切替は `ThemeToggleFab` (viewport 右上 fixed) に分離済み。
- * Profile 編集 / Logout は Settings モーダルに統合済み。
+ * Chat の起点は画面下のガラス型 FloatingChatInput に集約済み。
+ * ここに残すアイコンは **Settings の 1 つのみ**。
+ * (ダークモード切替は `ThemeToggleFab`、Profile / Logout は Settings モーダル)
  */
-const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, onOpenSettings, onShowChat }) => {
+const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, onOpenSettings }) => {
   return (
     <section className="card overflow-hidden">
       {profile.headerImageUrl && (
@@ -43,32 +39,19 @@ const ProfileHeader: React.FC<ProfileHeaderProps> = ({ profile, onOpenSettings, 
           </div>
         </div>
 
-        {/* 右: Chat + Settings の 2 アイコン */}
+        {/* 右: Settings の 1 アイコン (Chat は FloatingChatInput に集約) */}
         <div className="flex items-center gap-1">
-          {onShowChat && (
-            <button
-              type="button"
-              onClick={onShowChat}
-              className="icon-btn"
-              aria-label="Open chat (Add / Advisor)"
-              title="Chat — add gear & advisor"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M8 10h.01M12 10h.01M16 10h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-            </button>
-          )}
-
           <button
             type="button"
             onClick={onOpenSettings}
             className="icon-btn"
             aria-label="Open settings"
-            title="Settings"
+            title="More"
           >
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <circle cx="12" cy="5"  r="1.4" fill="currentColor" />
+              <circle cx="12" cy="12" r="1.4" fill="currentColor" />
+              <circle cx="12" cy="19" r="1.4" fill="currentColor" />
             </svg>
           </button>
         </div>

--- a/client/components/SettingsModal.tsx
+++ b/client/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { ProfileSettings, UserPlan } from '../hooks/useProfile';
 import { ProfileEditorForm } from './ProfileEditorModal';
+import { createCheckoutSession, createPortalSession } from '../services/billingService';
 
 interface SettingsModalProps {
   profile: ProfileSettings;
@@ -12,15 +13,23 @@ interface SettingsModalProps {
   onLogout: () => void;
 }
 
-type SettingsTab = 'profile' | 'account';
+type SettingsTab = 'profile' | 'account' | 'plan';
+
+const TABS: ReadonlyArray<{ key: SettingsTab; label: string }> = [
+  { key: 'profile', label: 'Profile' },
+  { key: 'account', label: 'Account' },
+  { key: 'plan',    label: 'Plan' },
+];
 
 /**
- * Settings モーダル — Profile / Account を tab で統合。
+ * Settings モーダル — Profile / Account / Plan を segmented tab で統合。
  *
  * Profile tab は既存の `ProfileEditorForm` を再利用。
  * Account tab はログイン済みユーザー情報 + Logout。
+ * Plan tab は契約プラン (free / pro) の表示 + アップグレード導線のプレースホルダ。
  *
- * Tab UI は `ChatSidebar` の Add / Advisor と同じ視覚言語を踏襲。
+ * Tab UI は globals.css の `.segmented` 共通スタイルに揃え、
+ * 選択中は surface-level-0 + shadow-sm で明示的に浮かせる。
  */
 const SettingsModal: React.FC<SettingsModalProps> = ({
   profile,
@@ -32,43 +41,46 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onLogout,
 }) => {
   const [tab, setTab] = useState<SettingsTab>('profile');
+  const [billingLoading, setBillingLoading] = useState(false);
+
+  const goToBilling = async (getUrl: () => Promise<string>, errorMessage: string) => {
+    setBillingLoading(true);
+    try {
+      window.location.href = await getUrl();
+    } catch (err) {
+      console.error('[Billing]', err);
+      alert(errorMessage);
+      setBillingLoading(false);
+    }
+  };
 
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-panel-md" onClick={(e) => e.stopPropagation()}>
-        {/* Header: tab bar + close */}
-        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 dark:border-gray-700">
-          <div role="tablist" aria-label="Settings section" className="inline-flex items-center gap-0.5 p-0.5 rounded-md bg-gray-100 dark:bg-gray-700">
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'profile'}
-              onClick={() => setTab('profile')}
-              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
-                          ${tab === 'profile'
-                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
-                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
-            >
-              Profile
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'account'}
-              onClick={() => setTab('account')}
-              className={`px-3 h-8 inline-flex items-center rounded text-xs font-semibold transition-colors
-                          ${tab === 'account'
-                            ? 'bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 shadow-sm'
-                            : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100'}`}
-            >
-              Account
-            </button>
+        {/* Header: segmented tab bar + close */}
+        <div
+          className="flex items-center justify-between px-3 py-2"
+          style={{ borderBottom: 'var(--border-divider)' }}
+        >
+          <div role="tablist" aria-label="Settings section" className="segmented">
+            {TABS.map(({ key, label }) => (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-pressed={tab === key}
+                aria-selected={tab === key}
+                onClick={() => setTab(key)}
+              >
+                {label}
+              </button>
+            ))}
           </div>
           <button
             type="button"
             onClick={onClose}
             aria-label="Close settings"
-            className="h-8 w-8 inline-flex items-center justify-center rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+            className="icon-btn"
           >
             <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -79,15 +91,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
         {/* Body */}
         <div className="px-4 py-3">
           {tab === 'profile' && (
-            <ProfileEditorForm profile={profile} onUpdate={onUpdate} plan={plan} />
+            <ProfileEditorForm profile={profile} onUpdate={onUpdate} />
           )}
           {tab === 'account' && (
             <div className="space-y-3">
               <div className="space-y-1.5">
-                <label className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                <label className="text-xs uppercase tracking-wide" style={{ color: 'var(--ink-muted)' }}>
                   Signed in as
                 </label>
-                <p className="text-sm text-gray-900 dark:text-gray-100">
+                <p className="text-sm" style={{ color: 'var(--ink-primary)' }}>
                   {isAuthenticated ? (userName ?? 'User') : 'Not signed in'}
                 </p>
               </div>
@@ -107,10 +119,64 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               )}
             </div>
           )}
+          {tab === 'plan' && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label className="text-xs uppercase tracking-wide" style={{ color: 'var(--ink-muted)' }}>
+                  Current plan
+                </label>
+                <p className="text-sm font-medium" style={{ color: 'var(--ink-primary)' }}>
+                  {plan === 'pro' ? 'Pro' : 'Free'}
+                </p>
+              </div>
+              {plan === 'free' ? (
+                <div className="pt-2 space-y-2">
+                  <p className="text-xs" style={{ color: 'var(--ink-muted)' }}>
+                    Upgrade to Pro for unlimited AI advisor usage and richer gear analytics.
+                  </p>
+                  <button
+                    type="button"
+                    className="btn-primary w-full disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={billingLoading}
+                    onClick={() =>
+                      goToBilling(
+                        createCheckoutSession,
+                        '決済ページを開けませんでした。時間をおいて再試行してください。',
+                      )
+                    }
+                  >
+                    {billingLoading ? 'Loading…' : 'Upgrade to Pro'}
+                  </button>
+                </div>
+              ) : (
+                <div className="pt-2 space-y-2">
+                  <p className="text-xs" style={{ color: 'var(--ink-muted)' }}>
+                    You&apos;re on Pro. Manage billing in the billing portal.
+                  </p>
+                  <button
+                    type="button"
+                    className="btn-secondary w-full disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={billingLoading}
+                    onClick={() =>
+                      goToBilling(
+                        createPortalSession,
+                        'サブスクリプション管理ページを開けませんでした。',
+                      )
+                    }
+                  >
+                    {billingLoading ? 'Loading…' : 'Manage subscription'}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         {/* Footer */}
-        <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-end">
+        <div
+          className="px-4 py-3 flex justify-end"
+          style={{ borderTop: 'var(--border-divider)' }}
+        >
           <button type="button" className="btn-primary" onClick={onClose}>
             Done
           </button>

--- a/client/components/WeightBreakdownCard.tsx
+++ b/client/components/WeightBreakdownCard.tsx
@@ -56,7 +56,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
     <Card hover className="p-3">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-xs font-semibold text-gray-900">
+        <h3 className="text-xs font-semibold" style={{ color: 'var(--ink-primary)' }}>
           WEIGHT BREAKDOWN
         </h3>
         <ULStatusBadge classification={ulStatus.classification} baseWeight={ulStatus.baseWeight} />
@@ -65,63 +65,72 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
       {/* Weight Class Cards */}
       <div className="grid grid-cols-3 gap-2 mb-3">
         {/* Base */}
-        <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-50">
-          <BackpackIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-2xs font-medium text-gray-500">
+        <div
+          className="flex flex-col items-center justify-center p-2 rounded-control"
+          style={{ background: 'var(--surface-level-1)' }}
+        >
+          <BackpackIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
+          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
             {WEIGHT_CLASS_CONFIG.base.label}
           </span>
-          <span className="text-sm font-bold text-gray-900">
+          <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>
             {formatWeight(breakdown.baseWeight, unit)}
           </span>
         </div>
 
         {/* Worn */}
-        <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-100">
-          <ShirtIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-2xs font-medium text-gray-500">
+        <div
+          className="flex flex-col items-center justify-center p-2 rounded-control"
+          style={{ background: 'var(--surface-level-2)' }}
+        >
+          <ShirtIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
+          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
             {WEIGHT_CLASS_CONFIG.worn.label}
           </span>
-          <span className="text-sm font-bold text-gray-900">
+          <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>
             {formatWeight(breakdown.wornWeight, unit)}
           </span>
         </div>
 
         {/* Consumable */}
-        <div className="flex flex-col items-center justify-center p-2 rounded-lg bg-gray-100">
-          <UtensilsIcon className="w-5 h-5 text-gray-500 mb-1" />
-          <span className="text-2xs font-medium text-gray-500">
+        <div
+          className="flex flex-col items-center justify-center p-2 rounded-control"
+          style={{ background: 'var(--surface-level-2)' }}
+        >
+          <UtensilsIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
+          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
             {WEIGHT_CLASS_CONFIG.consumable.label}
           </span>
-          <span className="text-sm font-bold text-gray-900">
+          <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>
             {formatWeight(breakdown.consumables, unit)}
           </span>
         </div>
       </div>
 
       {/* Divider */}
-      <div className="border-b border-gray-200 my-2" />
+      <div className="my-2" style={{ borderBottom: 'var(--border-divider)' }} />
 
       {/* Summary Stats */}
       <div className="space-y-1.5 text-xs">
         <div className="flex justify-between items-center">
-          <span className="text-gray-500">Packed Weight</span>
-          <span className="font-medium text-gray-900">
+          <span style={{ color: 'var(--ink-muted)' }}>Packed Weight</span>
+          <span className="font-medium" style={{ color: 'var(--ink-primary)' }}>
             {formatWeight(breakdown.packedWeight, unit)}
-            <span className="text-2xs text-gray-400 ml-1">(Base + Cons)</span>
+            <span className="text-2xs ml-1" style={{ color: 'var(--ink-disabled)' }}>(Base + Cons)</span>
           </span>
         </div>
         <div className="flex justify-between items-center">
-          <span className="text-gray-500">Skin-out Weight</span>
-          <span className="font-medium text-gray-900">
+          <span style={{ color: 'var(--ink-muted)' }}>Skin-out Weight</span>
+          <span className="font-medium" style={{ color: 'var(--ink-primary)' }}>
             {formatWeight(breakdown.skinOutWeight, unit)}
-            <span className="text-2xs text-gray-400 ml-1">(All)</span>
+            <span className="text-2xs ml-1" style={{ color: 'var(--ink-disabled)' }}>(All)</span>
           </span>
         </div>
         <div className="flex justify-between items-center">
-          <span className="text-gray-500">Big3</span>
-          <span className="font-medium text-gray-700">
+          <span style={{ color: 'var(--ink-muted)' }}>Big3</span>
+          <span className="font-medium" style={{ color: 'var(--ink-secondary)' }}>
             {formatWeight(breakdown.big3, unit)}
-            <span className="text-2xs text-gray-400 ml-1">(Pack+Shelter+Sleep)</span>
+            <span className="text-2xs ml-1" style={{ color: 'var(--ink-disabled)' }}>(Pack+Shelter+Sleep)</span>
           </span>
         </div>
       </div>
@@ -129,10 +138,10 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
       {/* UL Progress Bar */}
       <div className="mt-3">
         <div className="flex justify-between items-center mb-1">
-          <span className="text-2xs text-gray-500">
+          <span className="text-2xs" style={{ color: 'var(--ink-muted)' }}>
             Base Weight: {formatWeightLarge(breakdown.baseWeight, unit)}
           </span>
-          <span className="text-2xs text-gray-500">
+          <span className="text-2xs" style={{ color: 'var(--ink-muted)' }}>
             {Math.round(ulProgress)}% of UL limit
           </span>
         </div>
@@ -148,7 +157,7 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
             }}
           />
         </div>
-        <div className="text-3xs text-gray-400 mt-0.5 text-right">
+        <div className="text-3xs mt-0.5 text-right" style={{ color: 'var(--ink-disabled)' }}>
           UL limit: {formatWeightLarge(UL_THRESHOLDS.ultralight, unit)}
         </div>
       </div>

--- a/client/components/WeightBreakdownCard.tsx
+++ b/client/components/WeightBreakdownCard.tsx
@@ -67,10 +67,10 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Base */}
         <div
           className="flex flex-col items-center justify-center p-2 rounded-control"
-          style={{ background: 'var(--surface-level-1)' }}
+          style={{ background: 'var(--surface-level-1)', color: 'var(--ink-muted)' }}
         >
-          <BackpackIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
-          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
+          <BackpackIcon className="w-5 h-5 mb-1" />
+          <span className="text-2xs font-medium">
             {WEIGHT_CLASS_CONFIG.base.label}
           </span>
           <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>
@@ -81,10 +81,10 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Worn */}
         <div
           className="flex flex-col items-center justify-center p-2 rounded-control"
-          style={{ background: 'var(--surface-level-2)' }}
+          style={{ background: 'var(--surface-level-2)', color: 'var(--ink-muted)' }}
         >
-          <ShirtIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
-          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
+          <ShirtIcon className="w-5 h-5 mb-1" />
+          <span className="text-2xs font-medium">
             {WEIGHT_CLASS_CONFIG.worn.label}
           </span>
           <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>
@@ -95,10 +95,10 @@ const WeightBreakdownCard: React.FC<WeightBreakdownCardProps> = ({ breakdown, ul
         {/* Consumable */}
         <div
           className="flex flex-col items-center justify-center p-2 rounded-control"
-          style={{ background: 'var(--surface-level-2)' }}
+          style={{ background: 'var(--surface-level-2)', color: 'var(--ink-muted)' }}
         >
-          <UtensilsIcon className="w-5 h-5 mb-1" style={{ color: 'var(--ink-muted)' }} />
-          <span className="text-2xs font-medium" style={{ color: 'var(--ink-muted)' }}>
+          <UtensilsIcon className="w-5 h-5 mb-1" />
+          <span className="text-2xs font-medium">
             {WEIGHT_CLASS_CONFIG.consumable.label}
           </span>
           <span className="text-sm font-bold" style={{ color: 'var(--ink-primary)' }}>

--- a/client/components/charts/ChartHeader.tsx
+++ b/client/components/charts/ChartHeader.tsx
@@ -27,7 +27,10 @@ const ChartHeader: React.FC<ChartHeaderProps> = ({
 }) => {
   if (isCollapsed) {
     return (
-      <div className={`flex items-center justify-between px-3 py-2 border-b border-gray-200 flex-shrink-0`}>
+      <div
+        className="flex items-center justify-between px-2 sm:px-3 py-2 flex-shrink-0"
+        style={{ borderBottom: 'var(--border-divider)' }}
+      >
         <div className="flex items-center justify-center w-full">
           <button
             onClick={() => onToggleCollapsed(false)}
@@ -58,7 +61,10 @@ const ChartHeader: React.FC<ChartHeaderProps> = ({
   }
 
   return (
-    <div className="flex items-center justify-between px-3 py-2 border-b border-gray-200 flex-shrink-0 h-11">
+    <div
+      className="flex items-center justify-between px-2 sm:px-3 py-1 flex-shrink-0 h-control"
+      style={{ borderBottom: 'var(--border-divider)' }}
+    >
       <div className="flex items-center gap-2">
         <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Chart</h3>
         <div className="inline-flex items-center gap-0.5 bg-gray-100 dark:bg-gray-700 rounded-md p-0.5">

--- a/client/components/charts/ChartSummaryFooter.tsx
+++ b/client/components/charts/ChartSummaryFooter.tsx
@@ -8,6 +8,7 @@ import YenIcon from '../icons/YenIcon'
 import BackpackIcon from '../icons/BackpackIcon'
 import { useWeightUnit } from '../../contexts/WeightUnitContext'
 import { formatWeight } from '../../utils/weightUnit'
+import { useIsMobile } from '../../hooks/useResponsiveSize'
 
 const VIEW_MODE_OPTIONS = [
   { mode: 'weight', label: 'Weight', icon: ScaleIcon },
@@ -34,13 +35,19 @@ const SummaryStatCard: React.FC<SummaryStatCardProps> = ({
   wide = false,
   onClick,
 }) => {
+  const isMobile = useIsMobile()
+  // モバイルの 4 カード並びは横幅が厳しいため padding を圧縮 + label を text-3xs に逃がす
+  const stackedPad = isMobile ? 'px-0.5 py-1.5' : 'px-1 py-2'
   const cardClass = `flex items-center justify-center gap-3 rounded-md transition-all duration-200 ${
-    wide ? 'px-5 py-2' : 'flex-col px-1 py-2'
+    wide ? 'px-5 py-2' : `flex-col ${stackedPad}`
   } ${
     isActive
       ? 'bg-gray-200 dark:bg-gray-600 ring-1 ring-gray-400 dark:ring-gray-500'
       : 'bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
   }`
+
+  const stackedLabelClass = isMobile ? 'text-3xs' : 'text-2xs'
+  const stackedValueClass = isMobile ? 'text-2xs' : 'text-xs'
 
   const content = wide ? (
     <>
@@ -53,12 +60,14 @@ const SummaryStatCard: React.FC<SummaryStatCardProps> = ({
     </>
   ) : (
     <>
-      <div className="flex items-center gap-1.5 mb-1 leading-none">
+      <div className={`flex items-center gap-1 mb-0.5 leading-none ${isMobile ? '' : 'mb-1 gap-1.5'}`}>
         {icon}
-        <span className="text-2xs leading-none font-medium text-gray-600 dark:text-gray-300">{label}</span>
+        <span className={`${stackedLabelClass} leading-none font-medium text-gray-600 dark:text-gray-300`}>{label}</span>
       </div>
-      <span className="text-xs leading-none font-bold text-gray-900 dark:text-gray-100">{value}</span>
-      {subValue && <span className="text-3xs leading-none mt-1 text-gray-500 dark:text-gray-400">{subValue}</span>}
+      <span className={`${stackedValueClass} leading-none font-bold text-gray-900 dark:text-gray-100`}>{value}</span>
+      {subValue && !isMobile && (
+        <span className="text-3xs leading-none mt-1 text-gray-500 dark:text-gray-400">{subValue}</span>
+      )}
     </>
   )
 
@@ -91,10 +100,11 @@ const ChartSummaryFooter: React.FC<ChartSummaryFooterProps> = ({
   onToggleChartFocus,
 }) => {
   const { unit } = useWeightUnit()
+  const isMobile = useIsMobile()
   return (
     <div className="px-2 py-1.5 border-b border-gray-200">
       {/* view-mode toggle は中央、右端は viewMode に応じて g/oz or ¥/$ を出し分け */}
-      <div className="grid grid-cols-3 items-center mb-1.5">
+      <div className={`grid grid-cols-3 items-center ${isMobile ? 'mb-1' : 'mb-1.5'}`}>
         <div />
         <div className="justify-self-center">
           <SegmentedControl

--- a/client/components/charts/HorizontalBarChart.tsx
+++ b/client/components/charts/HorizontalBarChart.tsx
@@ -14,8 +14,10 @@ import { formatChartAxisValue } from '../../utils/chartHelpers'
 import { useWeightUnit } from '../../contexts/WeightUnitContext'
 import { primitiveColors, alpha } from '../../styles/tokens'
 import { formatWeight } from '../../utils/weightUnit'
+import { FONT_SIZES, BAR_LABEL_MAX_CHARS } from '../../utils/chartConfig'
 import GradientDefs, { grainFilterId } from './GradientDefs'
 import { CHART_CELL_TRANSITION, CHART_OPACITY_BASE, CHART_OPACITY_DIMMED } from './chartTokens'
+import { useChartGeometry } from './context/ChartGeometryContext'
 
 export interface BarItem {
   id?: string
@@ -55,26 +57,34 @@ const ChartTooltip: React.FC<TooltipProps<number, string>> = ({ active, payload 
   )
 }
 
-const YAXIS_WIDTH = 80
+const YAXIS_WIDTH_DESKTOP = 80
+const YAXIS_WIDTH_MOBILE = 70
 
 // YAxis カスタムティック（左寄せ）
+// recharts の `x` は tick line（YAxis 右端）位置で渡ってくるが、recharts 内部の
+// gap で `x < yAxisWidth` になるため `x - yAxisWidth + offset` だと左にはみ出す。
+// `payload.coordinate ?? 0` (= y軸内の相対位置) を起点に、開始 x を固定値で扱う。
 const CategoryTick: React.FC<{
   x?: number
   y?: number
   payload?: { value: string }
   selectedCategories: string[]
-}> = ({ x = 0, y = 0, payload, selectedCategories }) => {
+  fontSize: number
+  maxChars: number
+  /** 左パディング（固定 px） */
+  leftPad?: number
+}> = ({ y = 0, payload, selectedCategories, fontSize, maxChars, leftPad = 4 }) => {
   const name = payload?.value ?? ''
   const isSelected = selectedCategories.includes(name)
-  const label = name.length > 11 ? `${name.slice(0, 10)}…` : name
+  const label = name.length > maxChars ? `${name.slice(0, Math.max(1, maxChars - 1))}…` : name
   return (
     <text
-      x={x - YAXIS_WIDTH + 4}
+      x={leftPad}
       y={y}
       textAnchor="start"
       dominantBaseline="middle"
       style={{
-        fontSize: 10,
+        fontSize,
         fill: isSelected ? primitiveColors.gray[700] : primitiveColors.gray[500],
         fontWeight: isSelected ? 600 : 400,
       }}
@@ -99,8 +109,16 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   hoveredItemId,
 }) => {
   const { unit } = useWeightUnit()
+  const { screenSize } = useChartGeometry()
+  const isMobile = screenSize === 'mobile'
   const hasSelection = selectedCategories.length > 0
   const chartHeight = Math.max(MIN_CHART_HEIGHT, data.length * (BAR_HEIGHT + BAR_GAP) + HEIGHT_PADDING)
+
+  // モバイルは Y 軸幅を圧縮し、左マージンを 0 にしてカテゴリ名の収納幅を確保
+  const yAxisWidth = isMobile ? YAXIS_WIDTH_MOBILE : YAXIS_WIDTH_DESKTOP
+  const labelFontSize = isMobile ? FONT_SIZES.axis.label.mobile : FONT_SIZES.axis.label.desktop
+  const tickFontSize  = isMobile ? FONT_SIZES.axis.tick.mobile  : FONT_SIZES.axis.tick.desktop
+  const maxChars      = isMobile ? BAR_LABEL_MAX_CHARS.mobile   : BAR_LABEL_MAX_CHARS.desktop
 
   return (
     <div style={{ width: '100%', height: chartHeight }}>
@@ -112,35 +130,37 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
         <BarChart
           data={data}
           layout="vertical"
-          margin={{ top: 4, right: 12, left: 4, bottom: 4 }}
+          margin={{ top: 4, right: 12, left: isMobile ? 0 : 4, bottom: 4 }}
           barSize={BAR_HEIGHT}
           barCategoryGap={BAR_GAP}
         >
           <XAxis
             type="number"
             tickFormatter={(value: number) => formatChartAxisValue(value, viewMode, unit)}
-            tick={{ fontSize: 9, fill: primitiveColors.gray[400] }}
+            tick={{ fontSize: tickFontSize, fill: primitiveColors.gray[400] }}
             axisLine={false}
             tickLine={false}
           />
           <YAxis
             type="category"
             dataKey="name"
-            width={YAXIS_WIDTH}
+            width={yAxisWidth}
             axisLine={false}
             tickLine={false}
             tick={(props) => (
               <CategoryTick
-                x={props.x}
                 y={props.y}
                 payload={props.payload}
                 selectedCategories={selectedCategories}
+                fontSize={labelFontSize}
+                maxChars={maxChars}
               />
             )}
           />
           <Tooltip
             content={<ChartTooltip />}
             cursor={{ fill: alpha(primitiveColors.gray[400], 0.08) }}
+            wrapperStyle={{ outline: 'none', maxWidth: isMobile ? '70%' : undefined }}
           />
           <Bar
             dataKey="value"

--- a/client/components/ui/SkeletonLoader.tsx
+++ b/client/components/ui/SkeletonLoader.tsx
@@ -6,6 +6,14 @@ interface SkeletonLoaderProps {
   count?: number;
 }
 
+/**
+ * 読込中プレースホルダ。背景は `--surface-level-2` (沈み層)、内側ブロックは
+ * `--surface-level-1` (一段浮き) のトークン階層で表現し、light / dark を
+ * CSS 変数のみで切替える。
+ */
+const blockBg: React.CSSProperties = { background: 'var(--surface-level-2)' };
+const innerBg: React.CSSProperties = { background: 'var(--surface-level-1)' };
+
 const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({
   className = '',
   variant = 'text',
@@ -14,28 +22,32 @@ const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({
   const renderSkeletonContent = () => {
     if (variant === 'chart') {
       return (
-        <div className="h-[300px] w-full flex items-center justify-center flex-col animate-pulse bg-gray-200 dark:bg-gray-700 rounded-lg shadow-sm">
-          <div className="w-[120px] h-[120px] rounded-full bg-gray-300 dark:bg-gray-600 mb-4" />
-          <div className="w-[80px] h-3 bg-gray-300 dark:bg-gray-600 rounded-md" />
+        <div
+          className="h-[300px] w-full flex items-center justify-center flex-col animate-pulse rounded-surface"
+          style={{ ...blockBg, boxShadow: 'var(--shadow-sm)' }}
+        >
+          <div className="w-[120px] h-[120px] rounded-full mb-4" style={innerBg} />
+          <div className="w-[80px] h-3 rounded-control" style={innerBg} />
         </div>
       );
     }
 
     if (variant === 'table') {
       return (
-        <div className="h-[400px] w-full animate-pulse bg-gray-200 dark:bg-gray-700 rounded-lg shadow-sm">
+        <div
+          className="h-[400px] w-full animate-pulse rounded-surface"
+          style={{ ...blockBg, boxShadow: 'var(--shadow-sm)' }}
+        >
           <div className="space-y-3 w-full p-4">
-            {/* テーブルヘッダー */}
             <div className="grid grid-cols-6 gap-4">
               {Array.from({ length: 6 }).map((_, i) => (
-                <div key={i} className="h-4 bg-gray-300 dark:bg-gray-600 rounded" />
+                <div key={i} className="h-4 rounded-control" style={innerBg} />
               ))}
             </div>
-            {/* テーブル行 */}
             {Array.from({ length: 8 }).map((_, rowIndex) => (
               <div key={rowIndex} className="grid grid-cols-6 gap-4">
                 {Array.from({ length: 6 }).map((_, colIndex) => (
-                  <div key={colIndex} className="h-3.5 bg-gray-300 dark:bg-gray-600 rounded" />
+                  <div key={colIndex} className="h-3.5 rounded-control" style={innerBg} />
                 ))}
               </div>
             ))}
@@ -46,19 +58,31 @@ const SkeletonLoader: React.FC<SkeletonLoaderProps> = ({
 
     if (variant === 'card') {
       return Array.from({ length: count }).map((_, index) => (
-        <div key={index} className={`h-20 w-full animate-pulse bg-gray-200 dark:bg-gray-700 rounded-lg shadow-sm ${className}`} />
+        <div
+          key={index}
+          className={`h-20 w-full animate-pulse rounded-surface ${className}`}
+          style={{ ...blockBg, boxShadow: 'var(--shadow-sm)' }}
+        />
       ));
     }
 
     if (variant === 'circle') {
       return Array.from({ length: count }).map((_, index) => (
-        <div key={index} className={`h-10 w-10 animate-pulse bg-gray-200 dark:bg-gray-700 rounded-full shadow-sm ${className}`} />
+        <div
+          key={index}
+          className={`h-10 w-10 animate-pulse rounded-full ${className}`}
+          style={{ ...blockBg, boxShadow: 'var(--shadow-sm)' }}
+        />
       ));
     }
 
     // text variant
     return Array.from({ length: count }).map((_, index) => (
-      <div key={index} className={`h-4 w-full animate-pulse bg-gray-200 dark:bg-gray-700 rounded-lg shadow-sm ${className}`} />
+      <div
+        key={index}
+        className={`h-4 w-full animate-pulse rounded-control ${className}`}
+        style={{ ...blockBg, boxShadow: 'var(--shadow-sm)' }}
+      />
     ));
   };
 

--- a/client/hooks/useAdvisorChat.ts
+++ b/client/hooks/useAdvisorChat.ts
@@ -7,7 +7,10 @@ import {
   fetchMessages,
   createSession,
   saveMessage,
+  fetchSessions,
+  deleteSession,
   type AdvisorMessageRow,
+  type AdvisorSession,
 } from '../services/advisorSessionsApi';
 
 export interface SuggestedEditWithState extends SuggestedEdit {
@@ -21,6 +24,8 @@ export interface ChatMessage {
   content: string;
   suggestedEdits?: SuggestedEditWithState[];
   gearRefs?: GearRef[];
+  /** ＋メニューの Compare から挿入されるローカル比較パネル。DB 保存はしない */
+  comparison?: { itemIds: string[] };
   timestamp: Date;
 }
 
@@ -69,7 +74,13 @@ export const useAdvisorChat = (
   const [applyingEdit, setApplyingEdit] = useState<string | null>(null);
 
   // セッション ID（Lazy 作成: 最初のメッセージ送信時に作成）
+  // ref は sendText 等の closure から最新値を読むため、state は UI 表示・履歴ハイライト用。
   const sessionIdRef = useRef<string | null>(null);
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
+  const updateSessionId = useCallback((id: string | null) => {
+    sessionIdRef.current = id;
+    setCurrentSessionId(id);
+  }, []);
   const initializedRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -81,7 +92,7 @@ export const useAdvisorChat = (
   useEffect(() => {
     if (!isAuthenticated) {
       if (initializedRef.current) {
-        sessionIdRef.current = null;
+        updateSessionId(null);
         setMessages([createInitialMessage()]);
         initializedRef.current = false;
       }
@@ -99,7 +110,7 @@ export const useAdvisorChat = (
         const serverMessages = await fetchMessages(session.id);
         if (serverMessages.length === 0) return;
 
-        sessionIdRef.current = session.id;
+        updateSessionId(session.id);
         setMessages([
           createInitialMessage(),
           ...serverMessages.map(fromServerMessage),
@@ -110,7 +121,7 @@ export const useAdvisorChat = (
     };
 
     void restore();
-  }, [isAuthenticated]);
+  }, [isAuthenticated, updateSessionId]);
 
   // ストリーミング中断（パネルclose / unmount 時）
   useEffect(() => {
@@ -139,7 +150,7 @@ export const useAdvisorChat = (
       if (isAuthenticated && !sessionIdRef.current) {
         try {
           const session = await createSession();
-          sessionIdRef.current = session.id;
+          updateSessionId(session.id);
         } catch (err) {
           console.error('[Advisor] セッション作成失敗:', err);
         }
@@ -269,7 +280,7 @@ export const useAdvisorChat = (
       setIsStreaming(false);
       abortRef.current = null;
     }
-  }, [isLoading, gearContext, isAuthenticated]);
+  }, [isLoading, gearContext, isAuthenticated, updateSessionId]);
 
   /** 現在の入力欄テキストを送信 */
   const handleSend = useCallback(() => {
@@ -328,6 +339,71 @@ export const useAdvisorChat = (
     [onApplyEdit]
   );
 
+  /**
+   * ＋メニュー Compare から呼ばれ、チャット末尾にローカル比較パネルを 1 件差し込む。
+   * DB 保存は行わない（リロード後は消える想定）。
+   */
+  const appendComparison = useCallback((itemIds: string[]) => {
+    if (itemIds.length < 2) return;
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: createMessageId(),
+        role: 'assistant',
+        content: '',
+        comparison: { itemIds },
+        timestamp: new Date(),
+      },
+    ]);
+  }, []);
+
+  /**
+   * 過去セッションをロードしてチャット画面に展開する。
+   * 既存の messages を入れ替え、以後の send は対象セッションへ追記される。
+   */
+  const loadSession = useCallback(async (sessionId: string) => {
+    try {
+      const serverMessages = await fetchMessages(sessionId);
+      updateSessionId(sessionId);
+      setMessages([
+        createInitialMessage(),
+        ...serverMessages.map(fromServerMessage),
+      ]);
+    } catch (err) {
+      console.error('[Advisor] セッション読込エラー:', err);
+    }
+  }, [updateSessionId]);
+
+  /** 新しい会話を開始する。次の送信時に Lazy で session が作成される */
+  const startNewSession = useCallback(() => {
+    updateSessionId(null);
+    setMessages([createInitialMessage()]);
+  }, [updateSessionId]);
+
+  /** 履歴ドロップダウン用: セッション一覧を取得 */
+  const listSessions = useCallback(async (limit = 20): Promise<AdvisorSession[]> => {
+    if (!isAuthenticated) return [];
+    try {
+      return await fetchSessions(limit);
+    } catch (err) {
+      console.error('[Advisor] セッション一覧取得エラー:', err);
+      return [];
+    }
+  }, [isAuthenticated]);
+
+  /** 履歴ドロップダウン用: セッション削除 (現在表示中なら新規へ切替) */
+  const removeSession = useCallback(async (sessionId: string) => {
+    try {
+      await deleteSession(sessionId);
+      if (sessionIdRef.current === sessionId) {
+        updateSessionId(null);
+        setMessages([createInitialMessage()]);
+      }
+    } catch (err) {
+      console.error('[Advisor] セッション削除エラー:', err);
+    }
+  }, [updateSessionId]);
+
   return {
     messages,
     input,
@@ -339,6 +415,12 @@ export const useAdvisorChat = (
     sendText,
     handleApplyEdit,
     handleUndoEdit,
+    appendComparison,
+    currentSessionId,
+    loadSession,
+    startNewSession,
+    listSessions,
+    removeSession,
   };
 };
 

--- a/client/hooks/useAppState.ts
+++ b/client/hooks/useAppState.ts
@@ -11,6 +11,21 @@ export const useAppState = () => {
   // 全て削除済み。復活させる場合は各機能の再統合を先に検討すること。
   const [showChat, setShowChat] = useState(false);
 
+  // FloatingChatInput から送られた Advisor の初回プロンプト。
+  // nonce は同じテキストの連続送信を別イベントとして扱うための識別子。
+  const [pendingAdvisorPrompt, setPendingAdvisorPrompt] = useState<{ text: string; nonce: number } | null>(null);
+
+  /** FloatingChatInput から Advisor を起動: ChatSidebar を開き、テキストを自動送信する */
+  const launchAdvisor = useCallback((text: string) => {
+    setPendingAdvisorPrompt({ text, nonce: Date.now() });
+    setShowChat(true);
+  }, []);
+
+  /** ChatSidebar が消費したら呼び出してクリア */
+  const consumePendingAdvisorPrompt = useCallback(() => {
+    setPendingAdvisorPrompt(null);
+  }, []);
+
   // データ読み込み状態
   const [isLoading, setIsLoading] = useState(true);
 
@@ -128,6 +143,9 @@ export const useAppState = () => {
   return {
     // UI状態
     showChat, setShowChat,
+    pendingAdvisorPrompt,
+    launchAdvisor,
+    consumePendingAdvisorPrompt,
 
     // データ状態
     gearItems,

--- a/client/services/advisorSessionsApi.ts
+++ b/client/services/advisorSessionsApi.ts
@@ -34,6 +34,27 @@ export async function fetchLatestSession(): Promise<AdvisorSession | null> {
   return sessions.length > 0 ? sessions[0] : null;
 }
 
+/** セッション一覧を更新日時降順で取得 (デフォルト 20 件、最大 50) */
+export async function fetchSessions(limit = 20): Promise<AdvisorSession[]> {
+  const res = await callAPIWithRetry(
+    `/advisor/sessions?limit=${Math.min(limit, 50)}`,
+    {},
+    API_CONFIG.timeout.standard,
+    'GET',
+  );
+  return (res.data as AdvisorSession[]) ?? [];
+}
+
+/** セッションを削除（CASCADE で配下メッセージも消える） */
+export async function deleteSession(sessionId: string): Promise<void> {
+  await callAPIWithRetry(
+    `/advisor/sessions/${sessionId}`,
+    {},
+    API_CONFIG.timeout.standard,
+    'DELETE',
+  );
+}
+
 /** セッション内メッセージを取得 */
 export async function fetchMessages(sessionId: string): Promise<AdvisorMessageRow[]> {
   const res = await callAPIWithRetry(

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -243,7 +243,8 @@
     inset: 0;
     pointer-events: none;
     background-image: var(--noise-url);
-    mix-blend-mode: multiply;
+    /* light=multiply / dark=screen の切替を colors.ts のトークンで管理 */
+    mix-blend-mode: var(--noise-blend, multiply);
     opacity: var(--noise-opacity-surface);
     border-radius: inherit;
     z-index: 0;
@@ -264,16 +265,7 @@
   /* `.has-noise[data-noise="prominent|control"]` で粒度を切替できるオプション */
   .has-noise[data-noise="prominent"]::after { opacity: var(--noise-opacity-prominent); }
   .has-noise[data-noise="control"]::after   { opacity: var(--noise-opacity-control); }
-  /* ダークモード: screen 合成で粒を浮かせる */
-  .dark .card::after,
-  .dark .modal-content::after,
-  .dark .btn-primary::after,
-  .dark .btn-secondary::after,
-  .dark .btn-danger::after,
-  .dark .glass-header-chip::after,
-  .dark .has-noise::after {
-    mix-blend-mode: screen;
-  }
+  /* light/dark 切替は --noise-blend (colors.ts) が司る。個別 .dark override は不要 */
   /* 子要素を noise の上に重ねる (デフォルトの z-index: 0 と衝突しないよう明示) */
   .card > *,
   .modal-content > *,

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -79,17 +79,17 @@
     --surface-level-0: #FFFFFF;   /* L2 card / modal (最も明るい = "浮く") */
     --surface-level-1: #F7F5EE;   /* L1 nest / inset (card 内のネスト) */
     --surface-level-2: #E3E0D6;   /* L3 hover / selected (明示的に沈む) */
-    --ink-primary: #0A0A0A;
-    --ink-secondary: #3A3A38;
-    --ink-muted: #757570;
-    --ink-disabled: #A8A8A3;
+    --ink-primary: #0A0A0A;       /* 21:1 on level-0 */
+    --ink-secondary: #2E2E2C;     /* 13.8:1 on level-0 (旧 #3A3A38) */
+    --ink-muted: #5C5C58;         /* 6.9:1 on level-0 — AA Large + AAA小 (旧 #757570 4.2:1) */
+    --ink-disabled: #8E8E89;      /* 3.5:1 on level-0 — UI 用 (旧 #A8A8A3 2.7:1) */
     --ink-inverse: #FAFAF7;
-    --icon-default: #3A3A38;
-    --icon-muted: #757570;
-    --stroke-subtle:  rgba(10, 10, 10, 0.06);   /* hairline (input / divider) */
+    --icon-default: #2E2E2C;
+    --icon-muted: #5C5C58;
+    --stroke-subtle:  rgba(10, 10, 10, 0.10);   /* hairline (input / divider) — 旧 0.06 */
     --stroke-default: transparent;               /* borderless 既定: 枠線は描画しない */
-    --stroke-strong:  rgba(10, 10, 10, 0.14);    /* 明示的な額装 (mondrian-grid 等) */
-    --stroke-divider: rgba(10, 10, 10, 0.06);
+    --stroke-strong:  rgba(10, 10, 10, 0.20);    /* 明示的な額装 (mondrian-grid 等) — 旧 0.14 */
+    --stroke-divider: rgba(10, 10, 10, 0.10);    /* 旧 0.06 */
     --focus-ring: #1F3A93;              /* Mondrian Blue */
     --focus-ring-offset: #FAFAF7;
     --overlay-hover: rgba(10, 10, 10, 0.04);
@@ -167,12 +167,13 @@
     --surface-level-0: #434543;
     --surface-level-1: #2D2F2D;
     --surface-level-2: #1B1D1B;
-    --ink-primary: #F7F6F3;
-    --ink-secondary: #E0DFDD;
-    --ink-muted: #AFAFAC;
+    --ink-primary: #F7F6F3;       /* 10.9:1 on level-0 #434543 */
+    --ink-secondary: #E5E4E1;     /* 9.6:1 on level-0 (旧 #E0DFDD 7.6:1) */
+    --ink-muted: #C8C8C5;         /* 6.4:1 on level-0 — AA → AAA寄り (旧 #AFAFAC 4.3:1) */
+    --ink-disabled: #909090;      /* 3.3:1 on level-0 — UI 用 disabled */
     --ink-inverse: #2D2F2D;
-    --icon-default: #E0DFDD;
-    --icon-muted: #AFAFAC;
+    --icon-default: #E5E4E1;
+    --icon-muted: #C8C8C5;
     --stroke-subtle: rgba(148, 148, 146, 0.34);
     --stroke-default: rgba(175, 175, 172, 0.52);
     --stroke-strong: #CAC9C7;
@@ -228,13 +229,15 @@
 
   /* Paper grain overlay — card / modal / button / chip に共通の
    * マットなノイズ質感を ::after で重ねる。チャートの feTurbulence
-   * grain と同じ視覚言語をデザインシステム全体に適用する。 */
+   * grain と同じ視覚言語をデザインシステム全体に適用する。
+   * `.has-noise` は任意要素に同じ粒を乗せたい時に使う escape hatch (背景色は別途指定)。 */
   .card::after,
   .modal-content::after,
   .btn-primary::after,
   .btn-secondary::after,
   .btn-danger::after,
-  .glass-header-chip::after {
+  .glass-header-chip::after,
+  .has-noise::after {
     content: '';
     position: absolute;
     inset: 0;
@@ -245,6 +248,10 @@
     border-radius: inherit;
     z-index: 0;
   }
+  .has-noise {
+    position: relative;
+    overflow: hidden;
+  }
   /* ボタン / チップは主張を強めに */
   .btn-primary::after,
   .btn-danger::after {
@@ -254,13 +261,17 @@
   .glass-header-chip::after {
     opacity: var(--noise-opacity-control);
   }
+  /* `.has-noise[data-noise="prominent|control"]` で粒度を切替できるオプション */
+  .has-noise[data-noise="prominent"]::after { opacity: var(--noise-opacity-prominent); }
+  .has-noise[data-noise="control"]::after   { opacity: var(--noise-opacity-control); }
   /* ダークモード: screen 合成で粒を浮かせる */
   .dark .card::after,
   .dark .modal-content::after,
   .dark .btn-primary::after,
   .dark .btn-secondary::after,
   .dark .btn-danger::after,
-  .dark .glass-header-chip::after {
+  .dark .glass-header-chip::after,
+  .dark .has-noise::after {
     mix-blend-mode: screen;
   }
   /* 子要素を noise の上に重ねる (デフォルトの z-index: 0 と衝突しないよう明示) */
@@ -269,7 +280,8 @@
   .btn-primary > *,
   .btn-secondary > *,
   .btn-danger > *,
-  .glass-header-chip > * {
+  .glass-header-chip > *,
+  .has-noise > * {
     position: relative;
     z-index: 1;
   }

--- a/client/styles/tokens/colors.ts
+++ b/client/styles/tokens/colors.ts
@@ -216,6 +216,14 @@ export const colors = {
 };
 
 /**
+ * Paper grain noise — light/dark で同じ SVG 粒を使う。
+ * baseFrequency / numOctaves はチャートの feTurbulence と揃え、
+ * 視覚言語の一貫性を保つ。
+ */
+const NOISE_URL =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.1' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>\")";
+
+/**
  * UI Theme Tokens
  * CSS変数へ投影する色定義（light/dark）
  * フラット+影デザイン
@@ -293,6 +301,15 @@ export const theme: { light: ThemeColors; dark: ThemeColors } = {
       tableNum:   mondrian.black,
       tableMicro: gray[600],
     },
+    noise: {
+      url: NOISE_URL,
+      opacity: {
+        surface:   '0.09',
+        control:   '0.11',
+        prominent: '0.14',
+      },
+      blendMode: 'multiply',
+    },
   },
   dark: {
     page: {
@@ -364,6 +381,16 @@ export const theme: { light: ThemeColors; dark: ThemeColors } = {
       tableNum:   mondrian.canvas,
       tableMicro: '#BCBCBA',     // ↑ コントラスト改善
     },
+    noise: {
+      url: NOISE_URL,
+      // dark は粒を screen 合成で浮かせるため、light と同 opacity でも見え方が変わる。
+      opacity: {
+        surface:   '0.09',
+        control:   '0.11',
+        prominent: '0.14',
+      },
+      blendMode: 'screen',
+    },
   },
 };
 
@@ -408,6 +435,11 @@ const toThemeCssVariables = (tokens: ThemeColors): Record<string, string> => ({
   '--text-table-sub': tokens.text.tableSub,
   '--text-table-num': tokens.text.tableNum,
   '--text-table-micro': tokens.text.tableMicro,
+  '--noise-url': tokens.noise.url,
+  '--noise-opacity-surface':   tokens.noise.opacity.surface,
+  '--noise-opacity-control':   tokens.noise.opacity.control,
+  '--noise-opacity-prominent': tokens.noise.opacity.prominent,
+  '--noise-blend': tokens.noise.blendMode,
 });
 
 export const themeCssVariables = {

--- a/client/styles/tokens/colors.ts
+++ b/client/styles/tokens/colors.ts
@@ -248,10 +248,10 @@ export const theme: { light: ThemeColors; dark: ThemeColors } = {
       iconMuted: gray[600],
     },
     stroke: {
-      subtle:  alpha(mondrian.black, 0.06),
+      subtle:  alpha(mondrian.black, 0.10), // ↑ 0.06 → 0.10 (hairline 視認性向上)
       default: 'transparent', // borderless 既定
-      strong:  alpha(mondrian.black, 0.14),
-      divider: alpha(mondrian.black, 0.06),
+      strong:  alpha(mondrian.black, 0.20), // ↑ 0.14 → 0.20 (額装の存在感強化)
+      divider: alpha(mondrian.black, 0.10), // ↑ 0.06 → 0.10
     },
     focus: {
       ring:       mondrian.blue,
@@ -313,17 +313,17 @@ export const theme: { light: ThemeColors; dark: ThemeColors } = {
     },
     ink: {
       primary:   mondrian.canvas,
-      secondary: '#E0E0DC',
-      muted:     '#9C9C98',
+      secondary: '#E5E4E1',     // ↑ #E0E0DC → #E5E4E1 (9.6:1 vs 9.0:1)
+      muted:     '#BCBCBA',     // ↑ #9C9C98 → #BCBCBA (7.5:1 — AA→AAA)
       inverse:   mondrian.black,
-      icon:      '#E0E0DC',
-      iconMuted: '#9C9C98',
+      icon:      '#E5E4E1',
+      iconMuted: '#BCBCBA',
     },
     stroke: {
-      subtle:  alpha(mondrian.canvas, 0.08),
+      subtle:  alpha(mondrian.canvas, 0.12), // ↑ 0.08 → 0.12
       default: 'transparent',
-      strong:  alpha(mondrian.canvas, 0.18),
-      divider: alpha(mondrian.canvas, 0.08),
+      strong:  alpha(mondrian.canvas, 0.24), // ↑ 0.18 → 0.24
+      divider: alpha(mondrian.canvas, 0.12), // ↑ 0.08 → 0.12
     },
     focus: {
       ring:       '#5E73A8', // mondrian blue は dark で見えにくいので明るめ
@@ -360,9 +360,9 @@ export const theme: { light: ThemeColors; dark: ThemeColors } = {
     text: {
       tableHead:  '#CFCCC2',
       tableMain:  mondrian.canvas,
-      tableSub:   '#9C9C98',
+      tableSub:   '#BCBCBA',     // ↑ コントラスト改善
       tableNum:   mondrian.canvas,
-      tableMicro: '#9C9C98',
+      tableMicro: '#BCBCBA',     // ↑ コントラスト改善
     },
   },
 };

--- a/client/styles/tokens/types.ts
+++ b/client/styles/tokens/types.ts
@@ -226,4 +226,22 @@ export type ThemeColors = {
     tableNum: string;
     tableMicro: string;
   };
+  /**
+   * Noise / paper grain — `.card` / `.btn-*` / `.glass-header-chip` / `.has-noise`
+   * の ::after に乗せるマット質感の token。
+   *  - url: SVG feTurbulence の data URL
+   *  - opacity.surface  : 大面 (card / modal) — 控えめ
+   *  - opacity.control  : ボタン / chip — 中
+   *  - opacity.prominent: primary CTA — 強め
+   *  - blendMode        : 'multiply' (light) / 'screen' (dark)
+   */
+  noise: {
+    url: string;
+    opacity: {
+      surface: string;
+      control: string;
+      prominent: string;
+    };
+    blendMode: 'multiply' | 'screen';
+  };
 };

--- a/client/utils/chartConfig.ts
+++ b/client/utils/chartConfig.ts
@@ -19,7 +19,7 @@ export const CHART_CONFIG = {
     desktop: { outer: 112, inner: 76 }
   },
   centerMaxWidth: {
-    mobile: 80,
+    mobile: 96,   // 80 → 96 (中央テキストの折返しを抑える)
     tablet: 112,
     desktop: 144
   }
@@ -35,11 +35,23 @@ export const UL_BADGE_COLORS = {
 // フォントサイズトークン
 export const FONT_SIZES = {
   center: {
-    primary: { mobile: '1.1rem', desktop: '1.4rem' },      // 値表示
-    secondary: { mobile: '0.65rem', desktop: '0.75rem' },   // ラベル
-    tertiary: { mobile: '0.55rem', desktop: '0.65rem' }     // サブ情報
+    primary:   { mobile: '0.95rem', desktop: '1.4rem' },   // 値表示 — モバイルは 1.1 → 0.95rem
+    secondary: { mobile: '0.55rem', desktop: '0.75rem' },  // ラベル — モバイルは 0.65 → 0.55rem
+    tertiary:  { mobile: '0.5rem',  desktop: '0.65rem' }   // サブ情報 — モバイルは 0.55 → 0.5rem
   },
-  badge: { mobile: '0.5rem', desktop: '0.55rem' }
+  badge: { mobile: '0.5rem', desktop: '0.55rem' },
+  // Bar / 軸ラベル — recharts は数値 px を期待するため number で定義
+  axis: {
+    tick:  { mobile: 11, desktop: 11 },   // X 軸 (数値) — 9px ハードコードから引上げ
+    label: { mobile: 12, desktop: 11 },   // Y 軸 (カテゴリ) — モバイルで 1 段大きく
+  }
+} as const
+
+/** Bar Chart の Y 軸カテゴリラベルが省略前に保持できる最大文字数 */
+export const BAR_LABEL_MAX_CHARS = {
+  mobile: 8,    // Cooking までは入る
+  tablet: 11,
+  desktop: 14,
 } as const
 
 // ヘルパー関数は chartHelpers.ts に集約:


### PR DESCRIPTION
## Summary

- **Chat 起動 UX 刷新**: 画面下中央のガラス透明 FloatingChatInput を主な launcher にし、送信で ChatSidebar が右からスライドして Advisor モードで auto-send。ProfileHeader / AppDock の Chat ボタン経路は撤去
- **+ ボタン統合**: ChatSidebar 入力欄の \`+\` から Import gear / Compare を呼び出し、Compare はチャット内 mini パネル (CompactComparisonPanel) で表示
- **過去会話の履歴ドロップダウン**: ヘッダーの時計アイコンから最大 20 件のセッションを切替・削除、新規会話開始も可能
- **Design token 整合**: CompactSummary / TableRow / Profile / Settings / WeightBreakdown / Skeleton をハードコード gray から CSS 変数 (\`--ink-*\`, \`--surface-level-*\`, \`--stroke-*\`, \`--shadow-*\`) に統一。noise blend を colors.ts のトークンに集約
- **Chart モバイル最適化**: Bar 軸 fontSize / 幅 / margin を screenSize で分岐、ヘッダーを \`h-control\` に、Pie 中央テキストを mobile で 0.95rem / 0.55rem / 0.5rem に圧縮 + \`centerMaxWidth\` を 96 へ拡張

## Test plan
- [ ] \`npm run lint\` ✅
- [ ] \`npm run build\` ✅
- [ ] FloatingChatInput デスクトップ: 下中央 560px、ガラス + ホバー / フォーカス / 入力で背景濃化、Send は subtle → primary
- [ ] FloatingChatInput モバイル: 下端横長、Enter で ChatSidebar が右から全画面スライドイン
- [ ] ChatSidebar 履歴ドロップダウン: 一覧表示・選択でメッセージ展開・削除・新規会話
- [ ] ChatSidebar + ボタン: Import gear (URL / 製品名)、Compare (mini パネル) ともに動作
- [ ] Chart モバイル: Bar の Y 軸 \`Clothing\` \`Electro…\` などが左クリップなしで読める、Donut 中央 \`5261g\` / \`TOTAL WEIGHT\` が内側リング縁から余裕を持って表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)