### PR TITLE
perf(server): advisor メッセージ取得にカーソルベースページネーション (#56)

### DIFF
--- a/client/hooks/useAdvisorChat.ts
+++ b/client/hooks/useAdvisorChat.ts
@@ -96,14 +96,13 @@ export const useAdvisorChat = (
         const session = await fetchLatestSession();
         if (!session) return;
 
-        const serverMessages = await fetchMessages(session.id);
-        if (serverMessages.length === 0) return;
+        // サーバーは最新→古い順 (DESC) で返すため、表示用に逆順 (ASC) に並べる
+        const page = await fetchMessages(session.id, { limit: 50 });
+        if (page.messages.length === 0) return;
 
         sessionIdRef.current = session.id;
-        setMessages([
-          createInitialMessage(),
-          ...serverMessages.map(fromServerMessage),
-        ]);
+        const ordered = [...page.messages].reverse().map(fromServerMessage);
+        setMessages([createInitialMessage(), ...ordered]);
       } catch (err) {
         console.error('[Advisor] セッション復元エラー:', err);
       }

--- a/client/services/advisorSessionsApi.ts
+++ b/client/services/advisorSessionsApi.ts
@@ -34,15 +34,30 @@ export async function fetchLatestSession(): Promise<AdvisorSession | null> {
   return sessions.length > 0 ? sessions[0] : null;
 }
 
-/** セッション内メッセージを取得 */
-export async function fetchMessages(sessionId: string): Promise<AdvisorMessageRow[]> {
-  const res = await callAPIWithRetry(
-    `/advisor/sessions/${sessionId}/messages`,
-    {},
-    API_CONFIG.timeout.standard,
-    'GET',
-  );
-  return res.data as AdvisorMessageRow[];
+export interface MessagesPage {
+  /** 最新→古い順（DESC）。表示時は逆順にする */
+  messages: AdvisorMessageRow[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+/**
+ * セッション内メッセージを取得（カーソルベースページネーション）
+ * @param sessionId セッション ID
+ * @param opts limit: 取得件数 (default 50, max 100), before: 古い側カーソル (メッセージ ID)
+ */
+export async function fetchMessages(
+  sessionId: string,
+  opts: { limit?: number; before?: string } = {},
+): Promise<MessagesPage> {
+  const params = new URLSearchParams();
+  if (opts.limit !== undefined) params.set('limit', String(opts.limit));
+  if (opts.before) params.set('before', opts.before);
+  const qs = params.toString();
+  const path = `/advisor/sessions/${sessionId}/messages${qs ? `?${qs}` : ''}`;
+
+  const res = await callAPIWithRetry(path, {}, API_CONFIG.timeout.standard, 'GET');
+  return res.data as MessagesPage;
 }
 
 /** セッション作成 */

--- a/server/routes/__tests__/advisor.test.ts
+++ b/server/routes/__tests__/advisor.test.ts
@@ -116,14 +116,14 @@ describe('Advisor API routes', () => {
   });
 
   describe('GET /api/v1/advisor/sessions/:id/messages', () => {
-    it('セッション内メッセージを返す', async () => {
+    it('セッション内メッセージを最新→古い順で返す（hasMore=false）', async () => {
       // 所有権チェック
       mockQuery.mockResolvedValueOnce({ rows: [{ id: 'session-1' }] });
-      // メッセージ取得
+      // メッセージ取得（DESC、limit+1=51 件のうち 2 件返却）
       mockQuery.mockResolvedValueOnce({
         rows: [
-          { id: 'msg-1', role: 'user', content: 'Hello', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:00:00Z' },
           { id: 'msg-2', role: 'assistant', content: 'Hi!', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:01:00Z' },
+          { id: 'msg-1', role: 'user', content: 'Hello', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:00:00Z' },
         ],
       });
 
@@ -131,9 +131,70 @@ describe('Advisor API routes', () => {
       const res = await request(app).get('/api/v1/advisor/sessions/session-1/messages');
 
       expect(res.status).toBe(200);
-      expect(res.body.data).toHaveLength(2);
-      expect(res.body.data[0].role).toBe('user');
-      expect(res.body.data[1].role).toBe('assistant');
+      expect(res.body.data.messages).toHaveLength(2);
+      expect(res.body.data.messages[0].id).toBe('msg-2');
+      expect(res.body.data.hasMore).toBe(false);
+      expect(res.body.data.nextCursor).toBeNull();
+    });
+
+    it('limit を超えたら hasMore=true と nextCursor を返す', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'session-1' }] });
+      // limit=2 に対し 3 件返ったケース
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 'msg-3', role: 'assistant', content: 'c', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:02:00Z' },
+          { id: 'msg-2', role: 'user', content: 'b', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:01:00Z' },
+          { id: 'msg-1', role: 'user', content: 'a', suggested_edits: null, gear_refs: null, created_at: '2026-04-12T00:00:00Z' },
+        ],
+      });
+
+      const app = createApp();
+      const res = await request(app).get('/api/v1/advisor/sessions/session-1/messages?limit=2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.messages).toHaveLength(2);
+      expect(res.body.data.hasMore).toBe(true);
+      expect(res.body.data.nextCursor).toBe('msg-2');
+
+      // クエリの limit パラメータは limit + 1 (=3) で渡されること
+      const params = mockQuery.mock.calls[1][1] as unknown[];
+      expect(params[params.length - 1]).toBe(3);
+    });
+
+    it('limit は最大 100 に制限される', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'session-1' }] });
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const app = createApp();
+      await request(app).get('/api/v1/advisor/sessions/session-1/messages?limit=999');
+
+      const params = mockQuery.mock.calls[1][1] as unknown[];
+      expect(params[params.length - 1]).toBe(101); // 100 + 1
+    });
+
+    it('before カーソル指定時は created_at < cursor で絞り込む', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'session-1' }] }); // 所有権
+      mockQuery.mockResolvedValueOnce({ rows: [{ created_at: '2026-04-12T00:01:00Z' }] }); // カーソル lookup
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // メッセージ取得
+
+      const app = createApp();
+      const res = await request(app).get('/api/v1/advisor/sessions/session-1/messages?before=msg-2&limit=10');
+
+      expect(res.status).toBe(200);
+      const sql = mockQuery.mock.calls[2][0] as string;
+      expect(sql).toMatch(/created_at < \$2/);
+      const params = mockQuery.mock.calls[2][1] as unknown[];
+      expect(params[1]).toBe('2026-04-12T00:01:00Z');
+    });
+
+    it('不正な before カーソル（他セッションや存在しない ID）は 400 を返す', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 'session-1' }] });
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // カーソル lookup 空
+
+      const app = createApp();
+      const res = await request(app).get('/api/v1/advisor/sessions/session-1/messages?before=bogus');
+
+      expect(res.status).toBe(400);
     });
 
     it('他ユーザーのセッションは 404 を返す', async () => {

--- a/server/routes/advisor.ts
+++ b/server/routes/advisor.ts
@@ -71,10 +71,15 @@ router.delete('/sessions/:id', cognitoAuth, async (req: Request, res: Response) 
 
 // ==================== メッセージ ====================
 
-// GET /api/v1/advisor/sessions/:id/messages - セッション内メッセージ取得
+// GET /api/v1/advisor/sessions/:id/messages - セッション内メッセージ取得（カーソルベースページネーション）
+//   ?limit=50    : 取得件数（デフォルト 50、最大 100）
+//   ?before=<id> : 指定メッセージより前（古い）を取得
+//   レスポンス: { messages: 最新→古い順, hasMore, nextCursor }
 router.get('/sessions/:id/messages', cognitoAuth, async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 50, 1), 100);
+    const before = (req.query.before as string) || null;
 
     // 所有権チェック
     const sessionCheck = await db.query(
@@ -86,17 +91,43 @@ router.get('/sessions/:id/messages', cognitoAuth, async (req: Request, res: Resp
       return;
     }
 
-    // TODO: 将来メッセージ数が増えたらページネーション対応
+    // before カーソルの created_at を取得（同一セッション内のメッセージのみ有効）
+    let beforeCreatedAt: Date | null = null;
+    if (before) {
+      const cursorRes = await db.query(
+        'SELECT created_at FROM advisor_messages WHERE id = $1 AND session_id = $2',
+        [before, id],
+      );
+      if (cursorRes.rows.length === 0) {
+        res.status(400).json({ success: false, message: 'Invalid cursor' });
+        return;
+      }
+      beforeCreatedAt = cursorRes.rows[0].created_at;
+    }
+
+    // limit + 1 件取得して hasMore を判定
+    const params: unknown[] = [id];
+    let whereClause = 'WHERE session_id = $1';
+    if (beforeCreatedAt) {
+      params.push(beforeCreatedAt);
+      whereClause += ` AND created_at < $${params.length}`;
+    }
+    params.push(limit + 1);
+
     const result = await db.query(
       `SELECT id, role, content, suggested_edits, gear_refs, created_at
        FROM advisor_messages
-       WHERE session_id = $1
-       ORDER BY created_at ASC
-       LIMIT 100`,
-      [id],
+       ${whereClause}
+       ORDER BY created_at DESC, id DESC
+       LIMIT $${params.length}`,
+      params,
     );
 
-    const messages = result.rows.map((row) => ({
+    const hasMore = result.rows.length > limit;
+    const sliced = hasMore ? result.rows.slice(0, limit) : result.rows;
+    const nextCursor = hasMore ? sliced[sliced.length - 1].id : null;
+
+    const messages = sliced.map((row) => ({
       id: row.id,
       role: row.role,
       content: row.content,
@@ -105,7 +136,7 @@ router.get('/sessions/:id/messages', cognitoAuth, async (req: Request, res: Resp
       createdAt: row.created_at,
     }));
 
-    res.json({ success: true, data: messages });
+    res.json({ success: true, data: { messages, hasMore, nextCursor } });
   } catch (error) {
     logger.error({ err: error }, 'Error fetching advisor messages:');
     res.status(500).json({ success: false, message: 'Failed to fetch messages' });


### PR DESCRIPTION
## Summary
- `GET /api/v1/advisor/sessions/:id/messages` をカーソルベースページネーションに変更
- クエリ `?limit=` (default 50 / max 100) と `?before=<messageId>` を追加。`LIMIT 100` 固定の `TODO` を解消
- レスポンスを `data: { messages, hasMore, nextCursor }` に変更（最新→古い順、表示時は逆順化）
- client API ラッパー (`fetchMessages`) と `useAdvisorChat` を新形式に追従

## Closes
- #56

## Test plan
- [x] `vitest run server/routes/__tests__/advisor.test.ts` (14 件 pass — hasMore / limit 上限 / before 動作 / 不正カーソル のテスト追加)
- [x] `npm run lint`
- [x] `npm run build` / `npm run server:build`
- [ ] ステージングでログイン後、Advisor チャットの履歴復元が以前と同様に動作すること

---
_Generated by [Claude Code](https://claude.ai/code/session_013PZwM7U9mvuViZFgqyu7c6)_