### PR TITLE
feat(packs): Pack 公開リンクの仕上げ — 未認証閲覧 + isPublic トグル

### DIFF
--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -43,13 +43,29 @@ export default function App() {
     });
   }, [location.hash]);
 
+  // /p/:packId は認証不要の公開ページ。未認証でも表示する。
+  const isPublicPackRoute = location.pathname.startsWith('/p/');
+
   // 未認証時は CTA ランディングを表示して早期 return
   // (パスワードレス: Landing の onLogin で loginWithEmail を呼び、
   //  成功すると isAuthenticated が true になってこの分岐を抜ける)
-  if (!isAuthenticated) {
+  if (!isAuthenticated && !isPublicPackRoute) {
     return (
       <div className="min-h-screen">
         <Landing onLogin={loginWithEmail} />
+        <NotificationPopup messages={messages} onRemove={removeNotification} />
+      </div>
+    );
+  }
+
+  // 未認証 + 公開パックルート: PackDetailPage のみ表示（AppDock や PacksPage は出さない）
+  if (!isAuthenticated && isPublicPackRoute) {
+    return (
+      <div className="min-h-screen">
+        <ThemeToggleFab />
+        <Routes>
+          <Route path="/p/:packId" element={<PackDetailPage />} />
+        </Routes>
         <NotificationPopup messages={messages} onRemove={removeNotification} />
       </div>
     );

--- a/client/components/InventoryWorkspace.tsx
+++ b/client/components/InventoryWorkspace.tsx
@@ -35,7 +35,7 @@ interface InventoryWorkspaceProps {
   onCreatePack?: (name: string) => void;
   onDeletePack?: (packId: string) => void;
   // Pack 編集: インラインフォームから呼ぶ CRUD アクション
-  onUpdatePack?: (updates: { name: string; routeName?: string; description?: string }) => void;
+  onUpdatePack?: (updates: { name: string; routeName?: string; description?: string; isPublic?: boolean }) => void;
   onCopyPackLink?: () => void;
   onOpenPackPublic?: () => void;
 }

--- a/client/components/PackDetailPage.tsx
+++ b/client/components/PackDetailPage.tsx
@@ -1,44 +1,116 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { useAppState } from '../hooks/useAppState';
-import { usePacks } from '../hooks/usePacks';
+import { API_CONFIG } from '../services/api.client';
 import { formatPrice } from '../utils/formatters';
-import { getQuantityForDisplayMode } from '../utils/chartHelpers';
 import { formatWeight, formatWeightLarge } from '../utils/weightUnit';
 import { useWeightUnit } from '../contexts/WeightUnitContext';
 import CategoryBadge from './ui/CategoryBadge';
 import EmptyState from './ui/EmptyState';
 
-const fallbackUserId = 'local-user';
+/** 公開パック取得 API のレスポンス（snake_case）。 */
+interface PublicPackItemRow {
+  id: string;
+  name: string;
+  brand: string | null;
+  weight_grams: number | null;
+  price_cents: number | null;
+  required_quantity: number;
+  image_url: string | null;
+  product_url: string | null;
+  category_name: string | null;
+  category_color: string | null;
+}
+
+interface PublicPackResponse {
+  id: string;
+  name: string;
+  description: string | null;
+  route_name: string | null;
+  is_public: boolean;
+  author_name: string | null;
+  author_handle: string | null;
+  items: PublicPackItemRow[];
+}
+
+type FetchState =
+  | { status: 'loading' }
+  | { status: 'not-found' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; pack: PublicPackResponse };
 
 export default function PackDetailPage() {
   const { packId = '' } = useParams();
-  const { gearItems, isLoading } = useAppState();
-  const { getPackById } = usePacks(fallbackUserId);
   const { unit } = useWeightUnit();
-  const pack = getPackById(packId);
+  const [state, setState] = useState<FetchState>({ status: 'loading' });
 
-  const items = useMemo(
-    () => (pack ? gearItems.filter((item) => pack.itemIds.includes(item.id)) : []),
-    [pack, gearItems]
-  );
+  // 公開パックのみ取得（認証不要）。サーバー側で is_public=false は 404 を返す。
+  useEffect(() => {
+    if (!packId) {
+      setState({ status: 'not-found' });
+      return;
+    }
+
+    const controller = new AbortController();
+
+    (async () => {
+      try {
+        const response = await fetch(
+          `${API_CONFIG.baseUrl}/packs/public/${encodeURIComponent(packId)}`,
+          { signal: controller.signal },
+        );
+
+        if (response.status === 404) {
+          setState({ status: 'not-found' });
+          return;
+        }
+        if (!response.ok) {
+          setState({ status: 'error', message: `HTTP ${response.status}` });
+          return;
+        }
+
+        const json = (await response.json()) as { success: boolean; data?: PublicPackResponse; message?: string };
+        if (!json.success || !json.data) {
+          setState({ status: 'error', message: json.message ?? 'Failed to load pack' });
+          return;
+        }
+        setState({ status: 'ready', pack: json.data });
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        setState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to load pack' });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [packId]);
+
+  const items = state.status === 'ready' ? state.pack.items : [];
 
   const totalWeight = useMemo(
-    () => items.reduce((sum, item) => sum + (item.weightGrams || 0) * getQuantityForDisplayMode(item, 'all'), 0),
-    [items]
+    () => items.reduce((sum, item) => sum + (item.weight_grams ?? 0) * item.required_quantity, 0),
+    [items],
   );
   const totalPrice = useMemo(
-    () => items.reduce((sum, item) => sum + (item.priceCents || 0) * getQuantityForDisplayMode(item, 'all'), 0),
-    [items]
+    () => items.reduce((sum, item) => sum + (item.price_cents ?? 0) * item.required_quantity, 0),
+    [items],
   );
 
-  if (!pack) {
+  if (state.status === 'loading') {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 md:px-8 lg:px-[16px] py-8">
+        <div className="card p-8 text-center">
+          <p className="text-sm text-gray-500 dark:text-gray-400">Loading pack...</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (state.status === 'not-found') {
     return (
       <main className="max-w-4xl mx-auto px-4 sm:px-6 md:px-8 lg:px-[16px] py-8">
         <div className="card p-8 text-center">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Pack not found</h2>
           <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">
-            This pack may have been removed from local storage.
+            This pack does not exist or is not public.
           </p>
           <Link to="/" className="inline-flex mt-4 h-9 items-center px-4 rounded-md btn-secondary text-sm">
             Back to Packs
@@ -48,11 +120,31 @@ export default function PackDetailPage() {
     );
   }
 
+  if (state.status === 'error') {
+    return (
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 md:px-8 lg:px-[16px] py-8">
+        <div className="card p-8 text-center">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Could not load pack</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">{state.message}</p>
+          <Link to="/" className="inline-flex mt-4 h-9 items-center px-4 rounded-md btn-secondary text-sm">
+            Back to Packs
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const { pack } = state;
+  const authorLabel = pack.author_name ?? (pack.author_handle ? `@${pack.author_handle}` : null);
+
   return (
     <main className="max-w-4xl mx-auto px-4 sm:px-6 md:px-8 lg:px-[16px] py-4">
       <section className="card p-4 mb-4">
         <p className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Public Pack</p>
         <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mt-1">{pack.name}</h1>
+        {authorLabel && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">by {authorLabel}</p>
+        )}
         {pack.description && <p className="text-sm text-gray-600 dark:text-gray-300 mt-2">{pack.description}</p>}
 
         <div className="mt-4 grid grid-cols-3 gap-2 text-xs">
@@ -77,42 +169,44 @@ export default function PackDetailPage() {
           <span>Weight</span>
           <span>Price</span>
         </div>
-        {isLoading && <p className="px-4 py-4 text-sm text-gray-500">Loading gear...</p>}
-        {!isLoading && items.length === 0 && (
+        {items.length === 0 && (
           <EmptyState
             compact
             title="このパックにはまだアイテムがありません"
-            description="ホーム画面のギア一覧から、このパックに追加するアイテムを選びましょう。"
+            description="作成者がアイテムを追加するとここに表示されます。"
           />
         )}
-        {!isLoading &&
-          items.map((item) => (
-            <div
-              key={item.id}
-              className="grid grid-cols-[1fr_auto_auto] gap-2 px-4 py-2 text-sm border-b border-gray-200 last:[box-shadow:none]"
-            >
-              <span className="flex items-center gap-2 min-w-0">
-                <img
-                  src={item.imageUrl || 'https://via.placeholder.com/56x56?text=No+Image'}
-                  alt={item.name}
-                  className="h-8 w-8 rounded object-cover"
-                  loading="lazy"
-                />
-                <span className="min-w-0">
-                  <span className="block text-gray-800 dark:text-gray-100 truncate">{item.name}</span>
-                  {item.category && (
-                    <CategoryBadge
-                      name={item.category.name}
-                      color={item.category.color}
-                      className="mt-0.5"
-                    />
-                  )}
-                </span>
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="grid grid-cols-[1fr_auto_auto] gap-2 px-4 py-2 text-sm border-b border-gray-200 last:[box-shadow:none]"
+          >
+            <span className="flex items-center gap-2 min-w-0">
+              <img
+                src={item.image_url || 'https://via.placeholder.com/56x56?text=No+Image'}
+                alt={item.name}
+                className="h-8 w-8 rounded object-cover"
+                loading="lazy"
+              />
+              <span className="min-w-0">
+                <span className="block text-gray-800 dark:text-gray-100 truncate">{item.name}</span>
+                {item.category_name && (
+                  <CategoryBadge
+                    name={item.category_name}
+                    color={item.category_color ?? undefined}
+                    className="mt-0.5"
+                  />
+                )}
               </span>
-              <span className="text-gray-700 dark:text-gray-200">{formatWeight((item.weightGrams || 0) * getQuantityForDisplayMode(item, 'all'), unit)}</span>
-              <span className="text-gray-700 dark:text-gray-200">{formatPrice((item.priceCents || 0) * getQuantityForDisplayMode(item, 'all'))}</span>
-            </div>
-          ))}
+            </span>
+            <span className="text-gray-700 dark:text-gray-200">
+              {formatWeight((item.weight_grams ?? 0) * item.required_quantity, unit)}
+            </span>
+            <span className="text-gray-700 dark:text-gray-200">
+              {formatPrice((item.price_cents ?? 0) * item.required_quantity)}
+            </span>
+          </div>
+        ))}
       </section>
     </main>
   );

--- a/client/components/PackInfoSection.tsx
+++ b/client/components/PackInfoSection.tsx
@@ -5,7 +5,7 @@ import { useOutsideClick } from '../hooks/useOutsideClick'
 interface PackInfoSectionProps {
   pack: Pack | null
   itemCount: number
-  onUpdate?: (updates: { name: string; routeName?: string; description?: string }) => void
+  onUpdate?: (updates: { name: string; routeName?: string; description?: string; isPublic?: boolean }) => void
   onDelete?: () => void
   onCopyLink?: () => void
   onOpenPublic?: () => void
@@ -39,6 +39,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
   const [name, setName] = useState(pack?.name ?? '')
   const [routeName, setRouteName] = useState(pack?.routeName ?? '')
   const [description, setDescription] = useState(pack?.description ?? '')
+  const [isPublic, setIsPublic] = useState(pack?.isPublic ?? false)
 
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -47,6 +48,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
     setName(pack?.name ?? '')
     setRouteName(pack?.routeName ?? '')
     setDescription(pack?.description ?? '')
+    setIsPublic(pack?.isPublic ?? false)
     // パック切替時は編集モードから抜ける
     setIsEditing(false)
     setMenuOpen(false)
@@ -57,7 +59,8 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
   const hasChanges =
     name.trim() !== (pack?.name ?? '') ||
     routeName.trim() !== (pack?.routeName ?? '') ||
-    description.trim() !== (pack?.description ?? '')
+    description.trim() !== (pack?.description ?? '') ||
+    isPublic !== (pack?.isPublic ?? false)
 
   const canSave = !!onUpdate && hasChanges && name.trim() !== ''
 
@@ -67,6 +70,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
       name: name.trim(),
       routeName: routeName.trim() || undefined,
       description: description.trim() || undefined,
+      isPublic,
     })
     setIsEditing(false)
   }
@@ -75,8 +79,14 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
     setName(pack?.name ?? '')
     setRouteName(pack?.routeName ?? '')
     setDescription(pack?.description ?? '')
+    setIsPublic(pack?.isPublic ?? false)
     setIsEditing(false)
   }
+
+  // 公開時のみ「公開ページを開く」「公開リンクをコピー」を表示
+  const showShareActions = !!pack?.isPublic
+  const showOpenPublic = showShareActions && !!onOpenPublic
+  const showCopyLink = showShareActions && !!onCopyLink
 
   if (!pack) return null
 
@@ -90,7 +100,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
         </h3>
 
         {/* ⋯ (three-dots) メニュー */}
-        {(onUpdate || onDelete || onCopyLink || onOpenPublic) && (
+        {(onUpdate || onDelete || showCopyLink || showOpenPublic) && (
           <div className="relative" ref={menuRef}>
             <button
               type="button"
@@ -121,7 +131,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
                     Edit
                   </button>
                 )}
-                {onOpenPublic && (
+                {showOpenPublic && onOpenPublic && (
                   <button
                     type="button"
                     role="menuitem"
@@ -131,7 +141,7 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
                     Open public page
                   </button>
                 )}
-                {onCopyLink && (
+                {showCopyLink && onCopyLink && (
                   <button
                     type="button"
                     role="menuitem"
@@ -201,6 +211,20 @@ const PackInfoSection: React.FC<PackInfoSectionProps> = ({
               placeholder="説明"
             />
           </div>
+          <label className="flex items-start gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="mt-0.5 h-3.5 w-3.5"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+            />
+            <span className="min-w-0">
+              <span className="block text-xs text-gray-700 dark:text-gray-200">Make this pack public</span>
+              <span className="block text-3xs text-gray-400 dark:text-gray-500">
+                ON にするとリンクを知っている人なら誰でも閲覧できます。OFF の場合 /p/&lt;id&gt; を開いても 404 になります。
+              </span>
+            </span>
+          </label>
           <div className="flex items-center justify-end gap-2">
             <button
               type="button"

--- a/client/hooks/useAppState.ts
+++ b/client/hooks/useAppState.ts
@@ -85,11 +85,22 @@ export const useAppState = () => {
   }, []);
 
   // 初回ロード
+  // どこかの fetch が throw しても isLoading が true のまま固定されないように、
+  // 例外をトップレベルで握りつぶし finally で必ず isLoading=false に落とす。
+  // 個別の fetch 関数も内部で setIsLoading(false) するが、
+  // fetchCategories のように isLoading を触らない関数で throw されると
+  // 永続スケルトン化するためここで保険をかける。
   useEffect(() => {
     const loadInitialData = async () => {
-      await fetchCategories();
-      await fetchGearItems();
-      await fetchWeightBreakdown();
+      try {
+        await fetchCategories();
+        await fetchGearItems();
+        await fetchWeightBreakdown();
+      } catch (err) {
+        console.error('Initial data load failed:', err);
+      } finally {
+        setIsLoading(false);
+      }
     };
     loadInitialData();
   }, [fetchCategories, fetchGearItems, fetchWeightBreakdown]);

--- a/client/hooks/usePacks.ts
+++ b/client/hooks/usePacks.ts
@@ -157,7 +157,8 @@ export const usePacks = (userId: string) => {
         routeName: routeName?.trim() || undefined,
         description: description?.trim() || undefined,
         itemIds: [],
-        isPublic: true,
+        // 新規パックは非公開で作成。ユーザーが編集 UI で明示的に公開を ON にする
+        isPublic: false,
         createdAt: now,
         updatedAt: now,
       };
@@ -171,7 +172,7 @@ export const usePacks = (userId: string) => {
           name,
           description: description?.trim() || undefined,
           routeName: routeName?.trim() || undefined,
-          isPublic: true,
+          isPublic: false,
         }),
       })
         .then((row) => {


### PR DESCRIPTION
## Summary

Pack の公開リンク機能の未完成部分を仕上げた。DB / API / UI 入口は既に実装済みだったが、以下のギャップがあったため修正:

- **未認証で `/p/:packId` が閲覧不可**: `App.tsx` の auth ガードがランディングを強制していた
- **`PackDetailPage` がログイン済みユーザーの `useAppState` を参照**: 訪問者には他人のギア情報が見えない
- **公開/非公開の切替 UI が無い**: `usePacks.createPack` で `isPublic: true` がハードコード

## Changes

- `client/components/PackDetailPage.tsx`: `/api/v1/packs/public/:id` 直叩きに変更（認証不要・items を埋め込みで返す既存 API）。404 / error / loading 状態を分岐
- `client/components/App.tsx`: `/p/:packId` のみ未認証でも `PackDetailPage` を描画（`AppDock` 等は出さない）
- `client/components/PackInfoSection.tsx`: 編集フォームに「Make this pack public」チェックボックスを追加。`isPublic` が true のときだけ「Open public page」「Copy public link」をメニューに表示
- `client/components/InventoryWorkspace.tsx`: `onUpdatePack` 型に `isPublic?: boolean` を追加
- `client/hooks/usePacks.ts`: 新規パック作成時の `isPublic` デフォルトを `true` → `false` に変更（共有はオプトイン）

サーバー側の `/api/v1/packs/public/:id` は既に `is_public = true` でフィルタしているので、非公開パックは 404 になる（追加変更なし）。

## Test plan

- [ ] ログイン済みユーザーで新規パックを作成 → デフォルトで非公開、メニューに共有リンクが出ないこと
- [ ] パック編集 → 「Make this pack public」を ON → 「Open public page」「Copy public link」が表示されること
- [ ] コピーした URL を別ブラウザ（未ログイン）で開くと、パック内容が表示されること
- [ ] 非公開のパックで `/p/:id` を直接開くと「Pack not found」と表示されること
- [ ] 既に `isPublic=true` のパックは従来通り共有メニューが見えること
- [ ] `npm run build` / `npm run server:build` がパスすること（typecheck / lint は既存の pre-existing 問題は残存）

https://claude.ai/code/session_01JPqzfFnpxsh9fTCqaDLvkK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPqzfFnpxsh9fTCqaDLvkK)_